### PR TITLE
Bodyroll modifications and improved convenience VMs

### DIFF
--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_cabrio_c_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_cabrio_c_comfort.json
@@ -7,21 +7,23 @@
     "hasTurnSignals": true,
     "emptyMass": 1100,
     "fuelCapacity": 10000,
-    "downForce": 0.6,
-    "overSteer": 0.5,
-    "underSteer": 2.0,
-    "overSteerAccel": -1.0,
-    "overSteerDecel": 2.0,
+    "downForce": 0.55,
+    "overSteer": 1.0,
+    "underSteer": 1.0,
     "axleRatio": 4.286,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -37,7 +39,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -52,7 +56,9 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -75,7 +81,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -96,75 +104,113 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,2.0],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,2.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,2.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,2.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,3.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.27,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [3,4,10,12,16,17,20,21]
     },
@@ -172,84 +218,116 @@
       "pos": [0.0,0.40625,4.48438],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-0.89063],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.1875,0.1875,-0.0625],
       "rot": [1.0,-3.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.1875,0.1875,-0.0625],
       "rot": [3.0,5.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.125,-0.5625],
       "rot": [-2.0,92.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.6875,0.40625,4.45625],
       "rot": [0.0,186.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.6875,0.40625,4.45625],
       "rot": [0.0,174.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5,1.0,0.25],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
       "defaultPart": "iv_tpp:roll_bar_small_gray",
-      "types": ["generic_rollbar_single"]
+      "types": [
+        "generic_rollbar_single"
+      ]
     },
     {
       "pos": [-0.5,1.0,0.25],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
       "defaultPart": "iv_tpp:roll_bar_small_gray",
-      "types": ["generic_rollbar_single"]
+      "types": [
+        "generic_rollbar_single"
+      ]
     }
   ],
   "collisionGroups": [
@@ -476,23 +554,42 @@
       "subName": "_pureblack_g",
       "name": "Trin Econobox Cabrio Coupe Comfort Trim - Pure Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_g",
       "name": "Trin Econobox Cabrio Coupe Comfort Trim - Lapender Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_milkcoffee_g",
       "name": "Trin Econobox Cabrio Coupe Comfort Trim - Milk Coffee Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_milkcoffee:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_milkcoffee:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -503,9 +600,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -514,10 +627,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -527,114 +638,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1342,8 +1525,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1365,16 +1549,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1389,8 +1582,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1408,12 +1604,27 @@
   },
   "general": {
     "description": "Low End Cabrio\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2200,
+    "health": 110,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:6","mts:iv_tpp.metal_pile_2:0:1"]
+      [
+        "mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:6",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_cabrio_c_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_cabrio_c_root.json
@@ -6,21 +6,23 @@
     "hasTurnSignals": true,
     "emptyMass": 1000,
     "fuelCapacity": 8000,
-    "downForce": 0.6,
-    "overSteer": 0.5,
-    "underSteer": 2.0,
-    "overSteerAccel": -1.0,
-    "overSteerDecel": 2.0,
+    "downForce": 0.55,
+    "overSteer": 1.0,
+    "underSteer": 1.0,
     "axleRatio": 4.286,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -36,7 +38,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -51,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -74,7 +80,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -95,75 +103,113 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,2.0],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,2.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,2.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,2.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,3.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.27,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [3,4,10,12,16,17,20,21]
     },
@@ -171,84 +217,116 @@
       "pos": [0.0,0.40625,4.48438],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-0.89063],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.1875,0.1875,-0.0625],
       "rot": [1.0,-3.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.1875,0.1875,-0.0625],
       "rot": [3.0,5.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.125,-0.5625],
       "rot": [-2.0,92.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.6875,0.40625,4.45625],
       "rot": [0.0,186.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.6875,0.40625,4.45625],
       "rot": [0.0,174.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5,1.0,0.25],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
       "defaultPart": "iv_tpp:roll_bar_small_gray",
-      "types": ["generic_rollbar_single"]
+      "types": [
+        "generic_rollbar_single"
+      ]
     },
     {
       "pos": [-0.5,1.0,0.25],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
       "defaultPart": "iv_tpp:roll_bar_small_gray",
-      "types": ["generic_rollbar_single"]
+      "types": [
+        "generic_rollbar_single"
+      ]
     }
   ],
   "collisionGroups": [
@@ -475,23 +553,42 @@
       "subName": "_purewhite_g",
       "name": "Trin Econobox Cabrio Coupe Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pink_g",
       "name": "Trin Econobox Cabrio Coupe Root Trim - Pink Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pink:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pink:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_oakgreen_g",
       "name": "Trin Econobox Cabrio Coupe Root Trim - Oak Green Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -502,9 +599,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -513,10 +626,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -526,114 +637,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1341,8 +1524,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1364,16 +1548,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1388,8 +1581,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1407,12 +1603,27 @@
   },
   "general": {
     "description": "Low End Cabrio\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2000,
+    "health": 110,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1","minecraft:iron_ingot:0:14","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:6","mts:iv_tpp.metal_pile_2:0:1"]
+      [
+        "mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1",
+        "minecraft:iron_ingot:0:14",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:6",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:7","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:7",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_hatchback_c_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_hatchback_c_comfort.json
@@ -6,21 +6,23 @@
     "hasTurnSignals": true,
     "emptyMass": 1160,
     "fuelCapacity": 10000,
-    "downForce": 0.6,
-    "overSteer": 0.5,
-    "underSteer": 2.0,
-    "overSteerAccel": -1.0,
-    "overSteerDecel": 2.0,
+    "downForce": 0.55,
+    "overSteer": 1.0,
+    "underSteer": 1.0,
     "axleRatio": 4.286,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -36,7 +38,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -51,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -74,7 +80,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -95,75 +103,113 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,2.0],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,2.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,2.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,2.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,3.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.27,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [3,4,10,12,13,14,15,19,20]
     },
@@ -171,90 +217,129 @@
       "pos": [0.0,0.40625,4.48438],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-0.89063],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,0.6875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.1875,0.1875,-0.0625],
       "rot": [1.0,-3.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.1875,0.1875,-0.0625],
       "rot": [3.0,5.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.125,-0.5625],
       "rot": [-2.0,92.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.6875,0.40625,4.45625],
       "rot": [0.0,186.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.6875,0.40625,4.45625],
       "rot": [0.0,174.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.3125],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     }
   ],
   "collisionGroups": [
@@ -486,23 +571,42 @@
       "subName": "_pureblack_g",
       "name": "Trin Econobox Hatchback Coupe Comfort Trim - Pure Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_g",
       "name": "Trin Econobox Hatchback Coupe Comfort Trim - Lapender Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_milkcoffee_g",
       "name": "Trin Econobox Hatchback Coupe Comfort Trim - Milk Coffee Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_milkcoffee:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_milkcoffee:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -513,9 +617,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -524,10 +644,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -537,114 +655,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1391,8 +1581,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1414,16 +1605,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1438,8 +1638,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1457,12 +1660,27 @@
   },
   "general": {
     "description": "Low End Hatchback\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2320,
+    "health": 116,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:6","mts:iv_tpp.metal_pile_2:0:1"]
+      [
+        "mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:6",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_hatchback_c_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_hatchback_c_root.json
@@ -5,21 +5,23 @@
     "hasTurnSignals": true,
     "emptyMass": 1060,
     "fuelCapacity": 8000,
-    "downForce": 0.6,
-    "overSteer": 0.5,
-    "underSteer": 2.0,
-    "overSteerAccel": -1.0,
-    "overSteerDecel": 2.0,
+    "downForce": 0.55,
+    "overSteer": 1.0,
+    "underSteer": 1.0,
     "axleRatio": 4.286,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -35,7 +37,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +54,9 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -73,7 +79,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -94,75 +102,113 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,2.0],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,2.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,2.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,2.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,3.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.27,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [3,4,10,12,13,14,15,19,20]
     },
@@ -170,90 +216,129 @@
       "pos": [0.0,0.40625,4.48438],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-0.89063],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,0.6875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.1875,0.1875,-0.0625],
       "rot": [1.0,-3.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.1875,0.1875,-0.0625],
       "rot": [3.0,5.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.125,-0.5625],
       "rot": [-2.0,92.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.6875,0.40625,4.45625],
       "rot": [0.0,186.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.6875,0.40625,4.45625],
       "rot": [0.0,174.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.3125],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     }
   ],
   "collisionGroups": [
@@ -485,23 +570,42 @@
       "subName": "_purewhite_g",
       "name": "Trin Econobox Hatchback Coupe Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pink_g",
       "name": "Trin Econobox Hatchback Coupe Root Trim - Pink Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pink:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pink:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_oakgreen_g",
       "name": "Trin Econobox Hatchback Coupe Root Trim - Oak Green Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -512,9 +616,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -523,10 +643,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -536,114 +654,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1366,8 +1556,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1389,16 +1580,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1413,8 +1613,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1432,12 +1635,27 @@
   },
   "general": {
     "description": "Low End Hatchback\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2120,
+    "health": 116,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1","minecraft:iron_ingot:0:14","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:6","mts:iv_tpp.metal_pile_2:0:1"]
+      [
+        "mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1",
+        "minecraft:iron_ingot:0:14",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:6",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:7","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:7",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_sedan_c_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_sedan_c_comfort.json
@@ -6,21 +6,23 @@
     "hasTurnSignals": true,
     "emptyMass": 1160,
     "fuelCapacity": 10000,
-    "downForce": 0.6,
-    "overSteer": 0.5,
-    "underSteer": 2.0,
-    "overSteerAccel": -1.0,
-    "overSteerDecel": 2.0,
+    "downForce": 0.55,
+    "overSteer": 1.0,
+    "underSteer": 1.0,
     "axleRatio": 4.286,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -36,7 +38,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -51,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -74,7 +80,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -95,75 +103,113 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,2.0],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,2.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,2.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,2.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,3.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.27,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [3,4,10,12,13,14,15,19,20]
     },
@@ -171,90 +217,129 @@
       "pos": [0.0,0.40625,4.48438],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-0.89063],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,0.6875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.1875,0.1875,-0.0625],
       "rot": [1.0,-3.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.1875,0.1875,-0.0625],
       "rot": [3.0,5.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.125,-0.5625],
       "rot": [-2.0,92.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.6875,0.40625,4.45625],
       "rot": [0.0,186.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.6875,0.40625,4.45625],
       "rot": [0.0,174.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.3125],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     }
   ],
   "collisionGroups": [
@@ -486,30 +571,57 @@
       "subName": "_pureblack_g",
       "name": "Trin Econobox Sedan Coupe Comfort Trim - Pure Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_g",
       "name": "Trin Econobox Sedan Coupe Comfort Trim - Lapender Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_milkcoffee_g",
       "name": "Trin Econobox Sedan Coupe Comfort Trim - Milk Coffee Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_milkcoffee:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_milkcoffee:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_harlequin_g",
       "name": "Trin Econobox Sedan Coupe Comfort Trim - Harlequin Livery, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_vibrantred:0:1","mts:iv_tpp.paint_bucket_oceanblue:0:1","mts:iv_tpp.paint_bucket_sunshineyellow:0:1","mts:iv_tpp.paint_bucket_slimelime:0:1","mts:iv_tpp.paint_bucket_turquoise:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_vibrantred:0:1",
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "mts:iv_tpp.paint_bucket_sunshineyellow:0:1",
+          "mts:iv_tpp.paint_bucket_slimelime:0:1",
+          "mts:iv_tpp.paint_bucket_turquoise:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -520,9 +632,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -531,10 +659,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -544,114 +670,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1405,8 +1603,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1428,16 +1627,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1452,8 +1660,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1471,12 +1682,27 @@
   },
   "general": {
     "description": "Low End Sedan Coupe\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2320,
+    "health": 116,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:6","mts:iv_tpp.metal_pile_2:0:1"]
+      [
+        "mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:6",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_sedan_c_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_sedan_c_root.json
@@ -5,21 +5,23 @@
     "hasTurnSignals": true,
     "emptyMass": 1060,
     "fuelCapacity": 8000,
-    "downForce": 0.6,
-    "overSteer": 0.5,
-    "underSteer": 2.0,
-    "overSteerAccel": -1.0,
-    "overSteerDecel": 2.0,
+    "downForce": 0.55,
+    "overSteer": 1.0,
+    "underSteer": 1.0,
     "axleRatio": 4.286,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -35,7 +37,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +54,9 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -73,7 +79,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -94,75 +102,113 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,2.0],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,2.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,2.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,2.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,3.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.27,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [3,4,10,12,13,14,15,19,20]
     },
@@ -170,90 +216,129 @@
       "pos": [0.0,0.40625,4.48438],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-0.89063],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,0.6875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.1875,0.1875,-0.0625],
       "rot": [1.0,-3.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.1875,0.1875,-0.0625],
       "rot": [3.0,5.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.125,-0.5625],
       "rot": [-2.0,92.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.6875,0.40625,4.45625],
       "rot": [0.0,186.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.6875,0.40625,4.45625],
       "rot": [0.0,174.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.3125],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     }
   ],
   "collisionGroups": [
@@ -485,23 +570,42 @@
       "subName": "_purewhite_g",
       "name": "Trin Econobox Sedan Coupe Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pink_g",
       "name": "Trin Econobox Sedan Coupe Root Trim - Pink Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pink:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pink:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_oakgreen_g",
       "name": "Trin Econobox Sedan Coupe Root Trim - Oak Green Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -512,9 +616,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -523,10 +643,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -536,114 +654,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1373,8 +1563,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1396,16 +1587,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1420,8 +1620,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1439,12 +1642,27 @@
   },
   "general": {
     "description": "Low End Sedan Coupe\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2120,
+    "health": 116,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1","minecraft:iron_ingot:0:14","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:6","mts:iv_tpp.metal_pile_2:0:1"]
+      [
+        "mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1",
+        "minecraft:iron_ingot:0:14",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:6",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:7","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:7",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_paneled_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_paneled_comfort.json
@@ -6,21 +6,23 @@
     "hasTurnSignals": true,
     "emptyMass": 1260,
     "fuelCapacity": 10000,
-    "downForce": 0.6,
-    "overSteer": 0.5,
-    "underSteer": 2.0,
-    "overSteerAccel": -1.0,
-    "overSteerDecel": 2.0,
+    "downForce": 0.55,
+    "overSteer": 1.0,
+    "underSteer": 1.0,
     "axleRatio": 4.286,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -36,7 +38,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -51,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -74,7 +80,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -95,37 +103,55 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,2.0],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,2.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,2.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,2.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,3.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.27,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [3,4,8,10,11,12,13,14,15]
     },
@@ -133,120 +159,179 @@
       "pos": [0.0,0.40625,4.48438],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-0.89063],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,0.6875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.6875,0.40625,4.45625],
       "rot": [0.0,186.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.6875,0.40625,4.45625],
       "rot": [0.0,174.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.3125],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [0.0,0.5625,0.8125],
       "rot": [3.0,-1.0,2.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,1.3125,0.8125],
       "rot": [-3.0,3.0,3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_20"],
-        ["door_boot"]
+        [
+          "part_present_20"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,1.3125,0.8125],
       "rot": [4.0,0.0,-1.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_20"],
-        ["door_boot"]
+        [
+          "part_present_20"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,-0.0625],
       "rot": [-7.0,2.0,-4.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,1.3125,-0.0625],
       "rot": [-3.0,9.0,3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_23"],
-        ["door_boot"]
+        [
+          "part_present_23"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,1.3125,-0.0625],
       "rot": [-2.0,-4.0,5.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_23"],
-        ["door_boot"]
+        [
+          "part_present_23"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     }
   ],
@@ -498,23 +583,42 @@
       "subName": "_pureblack_g",
       "name": "Trin Econobox Panel Van Comfort Trim - Pure Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_g",
       "name": "Trin Econobox Panel Van Comfort Trim - Lapender Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_milkcoffee_g",
       "name": "Trin Econobox Panel Van Comfort Trim - Milk Coffee Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_milkcoffee:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_milkcoffee:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -525,9 +629,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -536,10 +656,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -549,114 +667,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1392,7 +1582,6 @@
       }
     ],
     "customVariables": [],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1414,16 +1603,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1438,8 +1636,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1457,12 +1658,27 @@
   },
   "general": {
     "description": "Low End Van\n2 doors, 2 seats\n\nRecommended parts:\nAverage Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2520,
+    "health": 126,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:3","mts:iv_tpp.metal_pile_2:0:1"]
+      [
+        "mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:3",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_paneled_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_paneled_root.json
@@ -5,21 +5,23 @@
     "hasTurnSignals": true,
     "emptyMass": 1160,
     "fuelCapacity": 8000,
-    "downForce": 0.6,
-    "overSteer": 0.5,
-    "underSteer": 2.0,
-    "overSteerAccel": -1.0,
-    "overSteerDecel": 2.0,
+    "downForce": 0.55,
+    "overSteer": 1.0,
+    "underSteer": 1.0,
     "axleRatio": 4.286,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -35,7 +37,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +54,9 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -73,7 +79,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -94,37 +102,55 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,2.0],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,2.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,2.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,2.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,3.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.27,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [3,4,8,10,11,12,13,14,15]
     },
@@ -132,120 +158,179 @@
       "pos": [0.0,0.40625,4.48438],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-0.89063],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,0.6875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.6875,0.40625,4.45625],
       "rot": [0.0,186.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.6875,0.40625,4.45625],
       "rot": [0.0,174.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.3125],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [0.0,0.5625,0.8125],
       "rot": [3.0,-1.0,2.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,1.3125,0.8125],
       "rot": [-3.0,3.0,3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_20"],
-        ["door_boot"]
+        [
+          "part_present_20"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,1.3125,0.8125],
       "rot": [4.0,0.0,-1.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_20"],
-        ["door_boot"]
+        [
+          "part_present_20"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,-0.0625],
       "rot": [-7.0,2.0,-4.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,1.3125,-0.0625],
       "rot": [-3.0,9.0,3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_23"],
-        ["door_boot"]
+        [
+          "part_present_23"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,1.3125,-0.0625],
       "rot": [-2.0,-4.0,5.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_23"],
-        ["door_boot"]
+        [
+          "part_present_23"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     }
   ],
@@ -497,23 +582,42 @@
       "subName": "_purewhite_g",
       "name": "Trin Econobox Panel Van Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pink_g",
       "name": "Trin Econobox Panel Van Root Trim - Pink Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pink:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pink:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_oakgreen_g",
       "name": "Trin Econobox Panel Van Root Trim - Oak Green Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -524,9 +628,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -535,10 +655,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -548,114 +666,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1367,7 +1557,6 @@
       }
     ],
     "customVariables": [],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1389,16 +1578,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1413,8 +1611,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1432,12 +1633,27 @@
   },
   "general": {
     "description": "Low End Van\n2 doors, 2 seats\n\nRecommended parts:\nAverage Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2320,
+    "health": 126,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1","minecraft:iron_ingot:0:14","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:3","mts:iv_tpp.metal_pile_2:0:1"]
+      [
+        "mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1",
+        "minecraft:iron_ingot:0:14",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:3",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:7","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:7",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_windowed_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_windowed_comfort.json
@@ -6,21 +6,23 @@
     "hasTurnSignals": true,
     "emptyMass": 1260,
     "fuelCapacity": 10000,
-    "downForce": 0.6,
-    "overSteer": 0.5,
-    "underSteer": 2.0,
-    "overSteerAccel": -1.0,
-    "overSteerDecel": 2.0,
+    "downForce": 0.55,
+    "overSteer": 1.0,
+    "underSteer": 1.0,
     "axleRatio": 4.286,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -36,7 +38,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -51,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -74,7 +80,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -95,37 +103,55 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,2.0],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,2.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,2.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,2.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,3.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.27,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [3,4,8,10,11,12,13,14,15]
     },
@@ -133,120 +159,179 @@
       "pos": [0.0,0.40625,4.48438],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-0.89063],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,0.6875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.6875,0.40625,4.45625],
       "rot": [0.0,186.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.6875,0.40625,4.45625],
       "rot": [0.0,174.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.3125],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [0.0,0.5625,0.8125],
       "rot": [3.0,-1.0,2.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,1.3125,0.8125],
       "rot": [-3.0,3.0,3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_20"],
-        ["door_boot"]
+        [
+          "part_present_20"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,1.3125,0.8125],
       "rot": [4.0,0.0,-1.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_20"],
-        ["door_boot"]
+        [
+          "part_present_20"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,-0.0625],
       "rot": [-7.0,2.0,-4.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,1.3125,-0.0625],
       "rot": [-3.0,9.0,3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_23"],
-        ["door_boot"]
+        [
+          "part_present_23"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,1.3125,-0.0625],
       "rot": [-2.0,-4.0,5.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_23"],
-        ["door_boot"]
+        [
+          "part_present_23"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     }
   ],
@@ -498,23 +583,42 @@
       "subName": "_pureblack_g",
       "name": "Trin Econobox Window Van Comfort Trim - Pure Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_g",
       "name": "Trin Econobox Window Van Comfort Trim - Lapender Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_milkcoffee_g",
       "name": "Trin Econobox Window Van Comfort Trim - Milk Coffee Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_milkcoffee:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_milkcoffee:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -525,9 +629,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -536,10 +656,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -549,114 +667,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1392,7 +1582,6 @@
       }
     ],
     "customVariables": [],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1414,16 +1603,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1438,8 +1636,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1457,12 +1658,27 @@
   },
   "general": {
     "description": "Low End Van\n2 doors, 2 seats\n\nRecommended parts:\nAverage Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2520,
+    "health": 126,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
+      [
+        "mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:7","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:7",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_windowed_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_windowed_root.json
@@ -5,21 +5,23 @@
     "hasTurnSignals": true,
     "emptyMass": 1160,
     "fuelCapacity": 8000,
-    "downForce": 0.6,
-    "overSteer": 0.5,
-    "underSteer": 2.0,
-    "overSteerAccel": -1.0,
-    "overSteerDecel": 2.0,
+    "downForce": 0.55,
+    "overSteer": 1.0,
+    "underSteer": 1.0,
     "axleRatio": 4.286,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -35,7 +37,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +54,9 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -73,7 +79,9 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -94,37 +102,55 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5,0.375,2.0],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.375,2.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5,0.375,2.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5,0.38,2.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,3.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.27,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [3,4,8,10,11,12,13,14,15]
     },
@@ -132,120 +158,179 @@
       "pos": [0.0,0.40625,4.48438],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-0.89063],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.8125,0.6875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.6875,0.40625,4.45625],
       "rot": [0.0,186.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.6875,0.40625,4.45625],
       "rot": [0.0,174.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.21875,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.8125,1.3125],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [0.0,0.5625,0.8125],
       "rot": [3.0,-1.0,2.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,1.3125,0.8125],
       "rot": [-3.0,3.0,3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_20"],
-        ["door_boot"]
+        [
+          "part_present_20"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,1.3125,0.8125],
       "rot": [4.0,0.0,-1.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_20"],
-        ["door_boot"]
+        [
+          "part_present_20"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,-0.0625],
       "rot": [-7.0,2.0,-4.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,1.3125,-0.0625],
       "rot": [-3.0,9.0,3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_23"],
-        ["door_boot"]
+        [
+          "part_present_23"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,1.3125,-0.0625],
       "rot": [-2.0,-4.0,5.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["part_present_23"],
-        ["door_boot"]
+        [
+          "part_present_23"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     }
   ],
@@ -497,23 +582,42 @@
       "subName": "_purewhite_g",
       "name": "Trin Econobox Window Van Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pink_g",
       "name": "Trin Econobox Window Van Root Trim - Pink Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pink:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pink:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_oakgreen_g",
       "name": "Trin Econobox Window Van Root Trim - Oak Green Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -524,9 +628,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -535,10 +655,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -548,114 +666,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1367,7 +1557,6 @@
       }
     ],
     "customVariables": [],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1389,16 +1578,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1413,8 +1611,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.15625,-0.03125,0.65625],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1432,12 +1633,27 @@
   },
   "general": {
     "description": "Low End Van\n2 doors, 2 seats\n\nRecommended parts:\nAverage Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2320,
+    "health": 126,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1","minecraft:iron_ingot:0:14","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
+      [
+        "mts:iv_tpp.chassis_ld4_t14_i5_econobox:0:1",
+        "minecraft:iron_ingot:0:14",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:7","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:7",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_keipan_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_keipan_comfort.json
@@ -6,25 +6,28 @@
     "emptyMass": 900,
     "fuelCapacity": 10000,
     "downForce": 0.55,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 2,
+    "underSteer": 0.5,
+    "overSteerAccel": 4.0,
     "axleRatio": 3.4,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.5
+    "dragCoefficient": 0.5,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [0.9375,0.0,0.0],
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -33,13 +36,15 @@
       "rot": [0.0,180.0,0.0],
       "isMirrored": true,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -47,13 +52,15 @@
       "pos": [0.9375,0.0,2.375],
       "turnsWithSteer": true,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,2.375],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -69,13 +76,15 @@
       "turnsWithSteer": true,
       "isMirrored": true,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,2.375],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -90,28 +99,42 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.46875,0.875,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.46875,0.875,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.46875,0.875,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.46875,0.9,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
@@ -119,96 +142,132 @@
       "rot": [0.0,-90.0,0.0],
       "maxValue": 0.25,
       "intakeOffset": 2.0,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,12,13,14,15,16,21,22]
     },
     {
       "pos": [0.625,0.8125,-0.125],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.625,0.8125,-0.125],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.625,0.8125,1.0],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.625,0.8125,1.0],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.0,2.375,2.375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,2.375,2.0625],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [-0.65625,0.625,3.19375],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.5625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.5625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.4375,1.0,-0.3125],
       "rot": [1.0,-2.0,2.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.4375,1.0,-0.3125],
       "rot": [0.0,2.0,-3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [-0.4375,1.0,0.5],
       "rot": [2.0,-5.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.4375,1.0,0.5],
       "rot": [-2.0,1.0,3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.65625,0.625,3.20313],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.5,-0.82813],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -415,23 +474,42 @@
       "subName": "_spruce",
       "name": "Trin Keipan comfort trim - Spruce paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_spruce:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_spruce:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_tungsten",
       "name": "Trin Keipan comfort trim - Tungsten paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pourpre",
       "name": "Trin Keipan comfort trim - Carmin Red paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_carminred:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_carminred:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -442,9 +520,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -453,10 +547,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -466,114 +558,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1124,7 +1288,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1341,8 +1505,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1364,16 +1529,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,0.5,0.6406300067901611],
         "initialVelocity": [0.75,0.0,-0.75],
@@ -1388,8 +1562,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,0.5,0.6406300067901611],
         "initialVelocity": [0.75,0.0,-0.75],
@@ -1407,12 +1584,28 @@
   },
   "general": {
     "description": "Low End Off-road Kei Truck\n2 doors, 2 seats\n\nRecommended parts:\nAverage Sized Wheels\nTurbo Charged i4 Engine\nModel 3 Seats",
-    "health": 1800,
+    "health": 90,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:4","mts:iv_tpp.metal_pile_1:0:2","mts:iv_tpp.chassis_ld4_l4m_t14_i4_keipan:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:4",
+        "mts:iv_tpp.metal_pile_1:0:2",
+        "mts:iv_tpp.chassis_ld4_l4m_t14_i4_keipan:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["mts:iv_tpp.chassis_ld4_l4m_t14_i4_keipan:0:1","minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:4","mts:iv_tpp.metal_pile_1:0:1"]
-    ]
+      [
+        "mts:iv_tpp.chassis_ld4_l4m_t14_i4_keipan:0:1",
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:4",
+        "mts:iv_tpp.metal_pile_1:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_keipan_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_keipan_root.json
@@ -6,25 +6,28 @@
     "emptyMass": 800,
     "fuelCapacity": 9000,
     "downForce": 0.55,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 2,
+    "underSteer": 0.5,
+    "overSteerAccel": 4.0,
     "axleRatio": 3.0,
     "brakingFactor": 1.1,
-    "dragCoefficient": 0.5
+    "dragCoefficient": 0.5,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [0.9375,0.0,0.0],
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -33,13 +36,15 @@
       "rot": [0.0,180.0,0.0],
       "isMirrored": true,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -47,13 +52,15 @@
       "pos": [0.9375,0.0,2.375],
       "turnsWithSteer": true,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -69,13 +76,15 @@
       "turnsWithSteer": true,
       "isMirrored": true,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -90,28 +99,42 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.46875,0.875,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.46875,0.875,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.46875,0.875,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.46875,0.9,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
@@ -119,96 +142,132 @@
       "rot": [0.0,-90.0,0.0],
       "maxValue": 0.25,
       "intakeOffset": 2.0,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,12,13,14,15,16,21,22]
     },
     {
       "pos": [0.625,0.8125,-0.125],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.625,0.8125,-0.125],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.625,0.8125,1.0],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.625,0.8125,1.0],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.0,2.375,2.375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,2.375,2.0625],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [-0.65625,0.625,3.19375],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.65625,0.5625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.65625,0.5625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.4375,1.0,-0.3125],
       "rot": [1.0,-2.0,2.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.4375,1.0,-0.3125],
       "rot": [0.0,2.0,-3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [-0.4375,1.0,0.5],
       "rot": [2.0,-5.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.4375,1.0,0.5],
       "rot": [-2.0,1.0,3.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.65625,0.625,3.20313],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.5,-0.82813],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -415,23 +474,42 @@
       "subName": "_white",
       "name": "Trin Keipan root trim - white paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_sky_blue",
       "name": "Trin Keipan root trim - sky blue paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_skyblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_skyblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_silver",
       "name": "Trin Keipan root trim - silver paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_silver:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_silver:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -442,9 +520,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -453,10 +547,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -466,114 +558,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -957,7 +1121,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1245,8 +1409,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1268,16 +1433,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,0.5,0.6406300067901611],
         "initialVelocity": [0.75,0.0,-0.75],
@@ -1292,8 +1466,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,0.5,0.6406300067901611],
         "initialVelocity": [0.75,0.0,-0.75],
@@ -1311,12 +1488,27 @@
   },
   "general": {
     "description": "Low End Off-road Kei Truck\n2 doors, 2 seats\n\nRecommended parts:\nAverage Sized Wheels\ni3 Engine\nModel 3 Seats",
-    "health": 1600,
+    "health": 90,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_l4m_t14_i4_keipan:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:4","mts:iv_tpp.metal_pile_1:0:2"]
+      [
+        "mts:iv_tpp.chassis_ld4_l4m_t14_i4_keipan:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:4",
+        "mts:iv_tpp.metal_pile_1:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:4","mts:iv_tpp.metal_pile_1:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:4",
+        "mts:iv_tpp.metal_pile_1:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_comfort.json
@@ -7,20 +7,23 @@
     "emptyMass": 1380,
     "fuelCapacity": 15000,
     "downForce": 0.5,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -0.5,
+    "overSteer": 2,
+    "underSteer": 0.5,
+    "overSteerAccel": 4.0,
     "axleRatio": 4.781,
     "brakingFactor": 1.2,
-    "dragCoefficient": 0.7
+    "dragCoefficient": 0.7,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0625,0.0,0.0],
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -36,7 +39,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -51,7 +56,9 @@
       "turnsWithSteer": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -74,7 +81,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -95,56 +104,84 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,0.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.0,0.5625,0.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["doorR"]
+        [
+          "doorR"
+        ]
       ]
     },
     {
       "pos": [0.0,0.563,0.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["doorR"]
+        [
+          "part_present_8"
+        ],
+        [
+          "doorR"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,9,10,11,12,13,14,15]
     },
@@ -152,42 +189,60 @@
       "pos": [0.0,0.3125,4.25],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.875,1.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.21875,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.875,0.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["generic_rodeo_cabrio_roof"]
+      "types": [
+        "generic_rodeo_cabrio_roof"
+      ]
     }
   ],
   "collisionGroups": [
@@ -399,23 +454,42 @@
       "subName": "_jetblack_g",
       "name": "Trin Rodeo Cabrio comfort trim - jet black paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_jetblack:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_jetblack:0:1"
+        ]
       ]
     },
     {
       "subName": "_tungsten_g",
       "name": "Trin Rodeo Cabrio comfort trim - tungsten paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_tungsten:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_tungsten:0:1"
+        ]
       ]
     },
     {
       "subName": "_fireorange_g",
       "name": "Trin Rodeo Cabrio comfort trim - fire orange paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_fireorange:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_fireorange:0:1"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -426,9 +500,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -437,10 +527,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -450,114 +538,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1387,8 +1547,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1410,16 +1571,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1434,8 +1604,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1450,10 +1623,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1468,8 +1644,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1487,12 +1666,27 @@
   },
   "general": {
     "description": "Low end compact roof-off SUV\n\nRecommended parts:\nHuge Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2760,
+    "health": 138,
     "materialLists": [
-      ["mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_root.json
@@ -6,21 +6,24 @@
     "hasTurnSignals": true,
     "emptyMass": 1280,
     "fuelCapacity": 15000,
-    "downForce": 0.5,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -0.5,
+    "downForce": 0.55,
+    "overSteer": 3,
+    "underSteer": 0.25,
+    "overSteerAccel": 6.0,
     "axleRatio": 4.781,
     "brakingFactor": 1.2,
-    "dragCoefficient": 0.7
+    "dragCoefficient": 0.7,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0625,0.0,0.0],
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -36,7 +39,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -51,7 +56,9 @@
       "turnsWithSteer": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -74,7 +81,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -95,56 +104,84 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,0.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.0,0.5625,0.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["doorR"]
+        [
+          "doorR"
+        ]
       ]
     },
     {
       "pos": [0.0,0.563,0.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["doorR"]
+        [
+          "part_present_8"
+        ],
+        [
+          "doorR"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,10,13,14]
     },
@@ -152,42 +189,60 @@
       "pos": [0.0,0.3125,4.25],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.875,1.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.21875,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.875,0.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["generic_rodeo_cabrio_roof"]
+      "types": [
+        "generic_rodeo_cabrio_roof"
+      ]
     }
   ],
   "collisionGroups": [
@@ -399,23 +454,42 @@
       "subName": "_white_g",
       "name": "Trin Rodeo Cabrio root trim - white paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_white:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_white:0:1"
+        ]
       ]
     },
     {
       "subName": "_carminred_g",
       "name": "Trin Rodeo Cabrio root trim - carmin red paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_carminred:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_carminred:0:1"
+        ]
       ]
     },
     {
       "subName": "_teal_g",
       "name": "Trin Rodeo Cabrio root trim - teal paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_teal:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_teal:0:1"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -426,9 +500,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -437,10 +527,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -450,114 +538,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1387,8 +1547,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1410,16 +1571,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1434,8 +1604,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1453,12 +1626,27 @@
   },
   "general": {
     "description": "Low end compact roof-off SUV\n\nRecommended parts:\nHuge Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2560,
+    "health": 138,
     "materialLists": [
-      ["mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_comfort.json
@@ -6,20 +6,23 @@
     "emptyMass": 1380,
     "fuelCapacity": 15000,
     "downForce": 0.5,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -0.5,
+    "overSteer": 2,
+    "underSteer": 0.5,
+    "overSteerAccel": 4.0,
     "axleRatio": 4.781,
     "brakingFactor": 1.2,
-    "dragCoefficient": 0.7
+    "dragCoefficient": 0.7,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0625,0.0,0.0],
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -35,7 +38,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -73,7 +80,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -94,37 +103,55 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,8,9,12,13,14,15,16]
     },
@@ -132,59 +159,87 @@
       "pos": [0.0,0.3125,4.25],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.6875,0.5625,0.0],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.6875,0.5625,0.0],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.0,1.875,1.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.875,1.1875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.21875,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.6875,0.0],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["doorR"]
+        [
+          "doorR"
+        ]
       ]
     }
   ],
@@ -402,23 +457,42 @@
       "subName": "_jetblack_g",
       "name": "Trin Rodeo Pickup comfort trim - jet black paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_jetblack:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_jetblack:0:1"
+        ]
       ]
     },
     {
       "subName": "_tungsten_g",
       "name": "Trin Rodeo Pickup comfort trim - tungsten paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_tungsten:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_tungsten:0:1"
+        ]
       ]
     },
     {
       "subName": "_fireorange_g",
       "name": "Trin Rodeo Pickup comfort trim - fire orange paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_fireorange:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_fireorange:0:1"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -429,9 +503,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -440,10 +530,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -453,114 +541,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,4.0,6.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1414,8 +1574,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1437,16 +1598,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1461,8 +1631,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1477,10 +1650,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1495,8 +1671,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1514,12 +1693,31 @@
   },
   "general": {
     "description": "Low end compact Pickup\n\nRecommended parts:\nHuge Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2760,
+    "health": 138,
     "materialLists": [
-      ["mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_1:0:2"]
+      [
+        "mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_1:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_1:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_1:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_root.json
@@ -5,21 +5,24 @@
     "hasTurnSignals": true,
     "emptyMass": 1280,
     "fuelCapacity": 15000,
-    "downForce": 0.5,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -0.5,
+    "downForce": 0.55,
+    "overSteer": 3,
+    "underSteer": 0.25,
+    "overSteerAccel": 6.0,
     "axleRatio": 4.781,
     "brakingFactor": 1.2,
-    "dragCoefficient": 0.7
+    "dragCoefficient": 0.7,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0625,0.0,0.0],
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -35,7 +38,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -73,7 +80,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -94,37 +103,55 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,9,15,16]
     },
@@ -132,59 +159,87 @@
       "pos": [0.0,0.3125,4.25],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.6875,0.5625,0.0],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.6875,0.5625,0.0],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.0,1.875,1.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.875,1.1875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.21875,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.6875,0.0],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["doorR"]
+        [
+          "doorR"
+        ]
       ]
     }
   ],
@@ -402,23 +457,42 @@
       "subName": "_white_g",
       "name": "Trin Rodeo Pickup root trim - white paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_white:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_white:0:1"
+        ]
       ]
     },
     {
       "subName": "_carminred_g",
       "name": "Trin Rodeo Pickup root trim - carmin red paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_carminred:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_carminred:0:1"
+        ]
       ]
     },
     {
       "subName": "_teal_g",
       "name": "Trin Rodeo Pickup root trim - teal paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_teal:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_teal:0:1"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -429,9 +503,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -440,10 +530,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -453,114 +541,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1414,8 +1574,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1437,16 +1598,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1461,8 +1631,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1480,12 +1653,31 @@
   },
   "general": {
     "description": "Low end compact Pickup\n\nRecommended parts:\nHuge Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2560,
+    "health": 138,
     "materialLists": [
-      ["mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_1:0:2"]
+      [
+        "mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_1:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_1:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_1:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_comfort.json
@@ -6,20 +6,23 @@
     "emptyMass": 1380,
     "fuelCapacity": 15000,
     "downForce": 0.5,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -0.5,
+    "overSteer": 2,
+    "underSteer": 0.5,
+    "overSteerAccel": 4.0,
     "axleRatio": 4.781,
     "brakingFactor": 1.2,
-    "dragCoefficient": 0.7
+    "dragCoefficient": 0.7,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0625,0.0,0.0],
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -35,7 +38,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -73,7 +80,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -94,37 +103,55 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,8,9,10,11,12,13,14]
     },
@@ -132,54 +159,80 @@
       "pos": [0.0,0.3125,4.25],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.875,1.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.875,1.1875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.21875,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.875,0.625],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [0.0,0.6875,0.0],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["doorR"]
+        [
+          "doorR"
+        ]
       ]
     }
   ],
@@ -421,23 +474,42 @@
       "subName": "_jetblack_g",
       "name": "Trin Rodeo Van comfort trim - jet black paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_jetblack:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_jetblack:0:1"
+        ]
       ]
     },
     {
       "subName": "_tungsten_g",
       "name": "Trin Rodeo Van comfort trim - tungsten paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_tungsten:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_tungsten:0:1"
+        ]
       ]
     },
     {
       "subName": "_fireorange_g",
       "name": "Trin Rodeo Van comfort trim - fire orange paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_fireorange:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_fireorange:0:1"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -448,9 +520,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -459,10 +547,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -472,114 +558,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1459,8 +1617,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1482,16 +1641,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1506,8 +1674,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1522,10 +1693,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1540,8 +1714,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1559,12 +1736,27 @@
   },
   "general": {
     "description": "Low end compact Van\n\nRecommended parts:\nHuge Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2760,
+    "health": 138,
     "materialLists": [
-      ["mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_root.json
@@ -5,21 +5,24 @@
     "hasTurnSignals": true,
     "emptyMass": 1280,
     "fuelCapacity": 15000,
-    "downForce": 0.5,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -0.5,
+    "downForce": 0.55,
+    "overSteer": 3,
+    "underSteer": 0.25,
+    "overSteerAccel": 6.0,
     "axleRatio": 4.781,
     "brakingFactor": 1.2,
-    "dragCoefficient": 0.7
+    "dragCoefficient": 0.7,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0625,0.0,0.0],
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -35,7 +38,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -73,7 +80,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -94,37 +103,55 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,9,13,14]
     },
@@ -132,54 +159,80 @@
       "pos": [0.0,0.3125,4.25],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.875,1.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.875,1.1875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.21875,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.875,0.625],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [0.0,0.6875,0.0],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"],
+      "types": [
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["doorR"]
+        [
+          "doorR"
+        ]
       ]
     }
   ],
@@ -421,23 +474,42 @@
       "subName": "_white_g",
       "name": "Trin Rodeo Van root trim - white paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_white:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_white:0:1"
+        ]
       ]
     },
     {
       "subName": "_carminred_g",
       "name": "Trin Rodeo Van root trim - carmin red paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_carminred:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_carminred:0:1"
+        ]
       ]
     },
     {
       "subName": "_teal_g",
       "name": "Trin Rodeo Van root trim - teal paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_teal:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_teal:0:1"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -448,9 +520,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -459,10 +547,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -472,114 +558,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1459,8 +1617,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1482,16 +1641,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1506,8 +1674,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1525,12 +1696,27 @@
   },
   "general": {
     "description": "Low end compact Van\n\nRecommended parts:\nHuge Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2560,
+    "health": 138,
     "materialLists": [
-      ["mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_comfort.json
@@ -6,20 +6,23 @@
     "emptyMass": 1380,
     "fuelCapacity": 15000,
     "downForce": 0.5,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -0.5,
+    "overSteer": 2,
+    "underSteer": 0.5,
+    "overSteerAccel": 4.0,
     "axleRatio": 4.781,
     "brakingFactor": 1.2,
-    "dragCoefficient": 0.7
+    "dragCoefficient": 0.7,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0625,0.0,0.0],
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -35,7 +38,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -73,7 +80,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -94,56 +103,84 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,0.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.0,0.5625,0.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["doorR"]
+        [
+          "doorR"
+        ]
       ]
     },
     {
       "pos": [0.0,0.563,0.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["doorR"]
+        [
+          "part_present_8"
+        ],
+        [
+          "doorR"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,9,10,11,12,13,14,15]
     },
@@ -151,46 +188,68 @@
       "pos": [0.0,0.3125,4.25],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.875,1.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.875,1.1875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.21875,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.875,0.625],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     }
   ],
   "collisionGroups": [
@@ -431,23 +490,42 @@
       "subName": "_jetblack_g",
       "name": "Trin Rodeo Wagon comfort trim - jet black paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_jetblack:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_jetblack:0:1"
+        ]
       ]
     },
     {
       "subName": "_tungsten_g",
       "name": "Trin Rodeo Wagon comfort trim - tungsten paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_tungsten:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_tungsten:0:1"
+        ]
       ]
     },
     {
       "subName": "_fireorange_g",
       "name": "Trin Rodeo Wagon comfort trim - fire orange paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_fireorange:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_fireorange:0:1"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -458,9 +536,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -469,10 +563,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -482,114 +574,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1469,8 +1633,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1492,16 +1657,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1516,8 +1690,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1532,10 +1709,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1550,8 +1730,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1569,12 +1752,27 @@
   },
   "general": {
     "description": "Low end compact SUV\n\nRecommended parts:\nHuge Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2760,
+    "health": 138,
     "materialLists": [
-      ["mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_root.json
@@ -5,21 +5,24 @@
     "hasTurnSignals": true,
     "emptyMass": 1280,
     "fuelCapacity": 15000,
-    "downForce": 0.5,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -0.5,
+    "downForce": 0.55,
+    "overSteer": 3,
+    "underSteer": 0.25,
+    "overSteerAccel": 6.0,
     "axleRatio": 4.781,
     "brakingFactor": 1.2,
-    "dragCoefficient": 0.7
+    "dragCoefficient": 0.7,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0625,0.0,0.0],
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -35,7 +38,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +55,9 @@
       "turnsWithSteer": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -73,7 +80,9 @@
       "isMirrored": true,
       "minValue": 1.05,
       "maxValue": 1.13,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -94,56 +103,84 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,0.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.0,0.5625,0.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["doorR"]
+        [
+          "doorR"
+        ]
       ]
     },
     {
       "pos": [0.0,0.563,0.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["doorR"]
+        [
+          "part_present_8"
+        ],
+        [
+          "doorR"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,10,14,15]
     },
@@ -151,46 +188,68 @@
       "pos": [0.0,0.3125,4.25],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,1.875,1.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.875,1.1875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.21875,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.28125,-1.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.875,0.625],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     }
   ],
   "collisionGroups": [
@@ -431,23 +490,42 @@
       "subName": "_white_g",
       "name": "Trin Rodeo Wagon root trim - white paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_white:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_white:0:1"
+        ]
       ]
     },
     {
       "subName": "_carminred_g",
       "name": "Trin Rodeo Wagon root trim - carmin red paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_carminred:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_carminred:0:1"
+        ]
       ]
     },
     {
       "subName": "_teal_g",
       "name": "Trin Rodeo Wagon root trim - teal paint, gray interior",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3","mts:iv_tpp.paint_bucket_teal:0:1"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "mts:iv_tpp.paint_bucket_teal:0:1"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -458,9 +536,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -469,10 +563,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -482,114 +574,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.002]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1469,8 +1633,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1492,16 +1657,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1516,8 +1690,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.3125,0.0,-0.9375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1535,12 +1712,27 @@
   },
   "general": {
     "description": "Low end compact SUV\n\nRecommended parts:\nHuge Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2560,
+    "health": 138,
     "materialLists": [
-      ["mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_md4_l5m_t18_i4_rodeo:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_ropy_4door_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_ropy_4door_comfort.json
@@ -639,26 +639,64 @@
           "variable": "engine_isautomatic_1"
         },
         {
-          "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1.0,0.0,0.0],
-          "duration": 3
-        }
-      ]
-    },
-    {"_comment": "smooth braking if using gamepad or wheel/pedals",
-      "variable": "brakingFactor",
-      "animations": [
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
         },
         {
           "animationType": "translation",
-          "variable": "brake",
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
           "axis": [1.0,0.0,0.0]
+        }
+      ]
+    },
+    {"_comment": "Rev up the engine if drifting and throttle is applied",
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "_comment": "We don't want to constantly apply this effect, only when the vehicle is starting to drift",
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "_comment": "Increases axleRatio to simulate revving up",
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "_comment": "Requires throttle input for revving up",
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "_comment": "Tries to prevent engine from overrevving too hard, not perfect but it helps",
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
         }
       ]
     },
@@ -668,25 +706,40 @@
       "maxValue": 1.0,
       "animations": [
         {
+          "_comment": "Roll stiffness for gripping",
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
         },
         {
+          "_comment": "Roll stiffness for sliding/drifting",
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
+        },
+        {
+          "_comment": "Wheel is or isn't on the ground",
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "_comment": "If vehicle is dead, make it collapse",
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
+          "_comment": "Pitch stiffness",
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "_comment": "Returns variable to 0 when nothing is being added or subtracted",
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
@@ -696,25 +749,40 @@
       "maxValue": 1.0,
       "animations": [
         {
+          "_comment": "Roll stiffness for gripping",
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
         },
         {
+          "_comment": "Roll stiffness for sliding/drifting",
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
+        },
+        {
+          "_comment": "Wheel is or isn't on the ground",
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "_comment": "If vehicle is dead, make it collapse",
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
+          "_comment": "Pitch stiffness",
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "_comment": "Returns variable to 0 when nothing is being added or subtracted",
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
@@ -724,25 +792,40 @@
       "maxValue": 1.0,
       "animations": [
         {
+          "_comment": "Roll stiffness for gripping",
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
         },
         {
+          "_comment": "Roll stiffness for sliding/drifting",
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
+        },
+        {
+          "_comment": "Wheel is or isn't on the ground",
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "_comment": "If vehicle is dead, make it collapse",
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
+          "_comment": "Pitch stiffness",
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "_comment": "Returns variable to 0 when nothing is being added or subtracted",
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
@@ -752,25 +835,40 @@
       "maxValue": 1.0,
       "animations": [
         {
+          "_comment": "Roll stiffness for gripping",
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
         },
         {
+          "_comment": "Roll stiffness for sliding/drifting",
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
+        },
+        {
+          "_comment": "Wheel is or isn't on the ground",
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "_comment": "If vehicle is dead, make it collapse",
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
+          "_comment": "Pitch stiffness",
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "_comment": "Returns variable to 0 when nothing is being added or subtracted",
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1666,7 +1764,7 @@
   },
   "general": {
     "description": "Low End Hatchback\n4 doors, 4 seats\n\nRecommended parts:\nCompact Sized Wheels\nI4 Engine\nModel 3 Seats",
-    "health": 2400,
+    "health": 120,
     "materialLists": [
       ["mts:iv_tpp.chassis_ld4_l5m_i3_ropy:0:1","minecraft:iron_ingot:0:14","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:6","mts:iv_tpp.metal_pile_2:0:1"]
     ],

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_ropy_4door_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_ropy_4door_root.json
@@ -639,10 +639,24 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1.0,0.0,0.0],
-          "duration": 3
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0]
         }
       ]
     },
@@ -650,15 +664,49 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
           "variable": "brake",
           "axis": [1.0,0.0,0.0]
+        }
+      ]
+    },
+    {"_comment": "Rev up the engine if drifting and throttle is applied",
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
         }
       ]
     },
@@ -668,25 +716,40 @@
       "maxValue": 1.0,
       "animations": [
         {
+          "_comment": "Roll stiffness for gripping",
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
         },
         {
+          "_comment": "Roll stiffness for sliding/drifting",
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
+        },
+        {
+          "_comment": "Wheel is or isn't on the ground",
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "_comment": "If vehicle is dead, make it collapse",
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
+          "_comment": "Pitch stiffness",
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "_comment": "Returns variable to 0 when nothing is being added or subtracted",
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
@@ -696,25 +759,40 @@
       "maxValue": 1.0,
       "animations": [
         {
+          "_comment": "Roll stiffness for gripping",
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
         },
         {
+          "_comment": "Roll stiffness for sliding/drifting",
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
+        },
+        {
+          "_comment": "Wheel is or isn't on the ground",
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "_comment": "If vehicle is dead, make it collapse",
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
+          "_comment": "Pitch stiffness",
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "_comment": "Returns variable to 0 when nothing is being added or subtracted",
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
@@ -724,25 +802,40 @@
       "maxValue": 1.0,
       "animations": [
         {
+          "_comment": "Roll stiffness for gripping",
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
         },
         {
+          "_comment": "Roll stiffness for sliding/drifting",
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
+        },
+        {
+          "_comment": "Wheel is or isn't on the ground",
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "_comment": "If vehicle is dead, make it collapse",
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
+          "_comment": "Pitch stiffness",
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "_comment": "Returns variable to 0 when nothing is being added or subtracted",
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
@@ -752,25 +845,40 @@
       "maxValue": 1.0,
       "animations": [
         {
+          "_comment": "Roll stiffness for gripping",
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
         },
         {
+          "_comment": "Roll stiffness for sliding/drifting",
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
+        },
+        {
+          "_comment": "Wheel is or isn't on the ground",
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "_comment": "If vehicle is dead, make it collapse",
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
+          "_comment": "Pitch stiffness",
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,4.0,0.0]
+        },
+        {
+          "_comment": "Returns variable to 0 when nothing is being added or subtracted",
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1666,7 +1774,7 @@
   },
   "general": {
     "description": "Low End Hatchback\n4 doors, 4 seats\n\nRecommended parts:\nCompact Sized Wheels\nI3 Engine\nModel 3 Seats",
-    "health": 2120,
+    "health": 120,
     "materialLists": [
       ["mts:iv_tpp.chassis_ld4_l5m_i3_ropy:0:1","minecraft:iron_ingot:0:14","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:6","mts:iv_tpp.metal_pile_2:0:1"]
     ],

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_comfort.json
@@ -7,26 +7,29 @@
     "emptyMass": 2500,
     "fuelCapacity": 20000,
     "downForce": 0.6,
-    "overSteer": 2.5,
-    "underSteer": 3.0,
-    "overSteerAccel": 3.5,
-    "overSteerDecel": -3.0,
+    "overSteer": 3,
+    "underSteer": 0.5,
+    "overSteerAccel": 6,
     "axleRatio": 3.5,
     "brakingFactor": 1.5,
-    "dragCoefficient": 0.65
+    "dragCoefficient": 0.65,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.375,0.0,0.0],
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -50,13 +55,15 @@
       "pos": [0.9375,0.0,0.0],
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -66,13 +73,15 @@
       "isMirrored": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -81,13 +90,15 @@
       "turnsWithSteer": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,5.625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         },
         {
           "animationType": "rotation",
@@ -104,13 +115,15 @@
       "isMirrored": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,5.625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         },
         {
           "animationType": "rotation",
@@ -125,175 +138,249 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.9375,3.6875],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.9375,3.6875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.9375,3.6875],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,1.0,3.6875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fr"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.9375,2.375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.9375,2.375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,1.0,2.375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rl"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.9375,2.375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.9375,2.375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,1.0,2.375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_12"],
-        ["door_rr"]
+        [
+          "part_present_12"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,4.6875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.95,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,5,6,16,17,18,19,20,21,22,23,27,28]
     },
     {
       "pos": [0.9375,1.0625,-0.5625],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.9375,1.0625,-0.5625],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.9375,1.0625,0.5625],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.9375,1.0625,0.5625],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.0,2.375,3.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,2.375,2.75],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.625,0.46875,7.06875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.46875,7.06875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.9375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.9375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.4375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.4375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.8125,-1.125],
       "rot": [1.0,-2.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.8125,0.0],
       "rot": [-3.0,1.0,2.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.8125,1.125],
       "rot": [1.0,-3.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.5,7.1],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.5,-2.04],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -596,44 +683,79 @@
       "subName": "_pureblack_g",
       "name": "Trin Bultizorg comfort trim - pure black paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_w",
       "name": "Trin Bultizorg comfort trim - pure black paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:0:6","minecraft:wool:8:4"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:0:6",
+          "minecraft:wool:8:4"
+        ]
       ]
     },
     {
       "subName": "_firered_g",
       "name": "Trin Bultizorg comfort trim - fire red paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_firered_w",
       "name": "Trin Bultizorg comfort trim - fire red paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:0:6","minecraft:wool:8:4"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:0:6",
+          "minecraft:wool:8:4"
+        ]
       ]
     },
     {
       "subName": "_electricblue_g",
       "name": "Trin Bultizorg comfort trim - electric blue paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_electricblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_electricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_electricblue_w",
       "name": "Trin Bultizorg comfort trim - electric blue paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_electricblue:0:1","minecraft:wool:0:6","minecraft:wool:8:4"]
+        [
+          "mts:iv_tpp.paint_bucket_electricblue:0:1",
+          "minecraft:wool:0:6",
+          "minecraft:wool:8:4"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -644,9 +766,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -655,10 +793,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -668,126 +804,196 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-0.5,0.0],
-          "duration": 4
+          "axis": [0.0,-0.375,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "!ground_onground_2",
-          "axis": [0.0,-0.5,0.0],
-          "duration": 4
+          "variable": "!ground_onground_3",
+          "axis": [0.0,-0.375,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "!ground_onground_3",
-          "axis": [0.0,0.5,0.0],
-          "duration": 4
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "!ground_onground_2",
+          "axis": [0.0,0.375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,0.5,0.0],
-          "duration": 4
+          "axis": [0.0,0.375,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_5",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_6",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1432,7 +1638,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1775,7 +1981,6 @@
       }
     ],
     "customVariables": [],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
     "sounds": [
       {
         "name": "iv_tpp:big_fat_horn_of_doom",
@@ -1797,7 +2002,13 @@
             "forwardsDelay": -3
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       },
       {
         "name": "mts:air_brake_activating",
@@ -1808,7 +2019,13 @@
             "clampMin": 1.0,
             "clampMax": 1.0
           }
-        ]
+        ],
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       },
       {
         "name": "mts:backup_beeper",
@@ -1820,16 +2037,25 @@
             "clampMax": -1.0
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1844,8 +2070,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1860,10 +2089,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1878,8 +2110,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1897,12 +2132,29 @@
   },
   "general": {
     "description": "Mid End Heavy Dutty Dually Pickup Truck\n4 doors, 4 seats\n\nRecommended parts:\nGiant Sized Wheels\nHeavy Duty V8 Engine\nModel 1 Seats",
-    "health": 5000,
+    "health": 250,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:10","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:7","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.metal_pile_1:0:4","mts:iv_tpp.chassis_hd6_t20_hv10:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:10",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:7",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.metal_pile_1:0:4",
+        "mts:iv_tpp.chassis_hd6_t20_hv10:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:7","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.metal_pile_1:0:2"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:7",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.metal_pile_1:0:2"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_root.json
@@ -6,26 +6,29 @@
     "emptyMass": 2000,
     "fuelCapacity": 15000,
     "downForce": 0.6,
-    "overSteer": 2.5,
-    "underSteer": 3.0,
-    "overSteerAccel": 3.5,
-    "overSteerDecel": -3.0,
+    "overSteer": 3,
+    "underSteer": 0.5,
+    "overSteerAccel": 6,
     "axleRatio": 3.3,
     "brakingFactor": 1.5,
-    "dragCoefficient": 0.65
+    "dragCoefficient": 0.65,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.375,0.0,0.0],
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -35,13 +38,15 @@
       "isMirrored": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -49,13 +54,15 @@
       "pos": [0.9375,0.0,0.0],
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -65,13 +72,15 @@
       "isMirrored": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -80,13 +89,15 @@
       "turnsWithSteer": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,5.625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         },
         {
           "animationType": "rotation",
@@ -103,13 +114,15 @@
       "isMirrored": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,5.625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         },
         {
           "animationType": "rotation",
@@ -124,175 +137,249 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.9375,3.6875],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.9375,3.6875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.9375,3.6875],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,1.0,3.6875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fr"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.9375,2.375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.9375,2.375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,1.0,2.375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rl"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.9375,2.375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.9375,2.375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,1.0,2.375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_12"],
-        ["door_rr"]
+        [
+          "part_present_12"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,4.6875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.95,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,20,21,22,23,28]
     },
     {
       "pos": [0.9375,1.0625,-0.5625],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.9375,1.0625,-0.5625],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.9375,1.0625,0.5625],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.9375,1.0625,0.5625],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.0,2.375,3.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,2.375,2.75],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.625,0.46875,7.06875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.46875,7.06875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.9375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.9375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.4375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.4375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.8125,-1.125],
       "rot": [1.0,-2.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.8125,0.0],
       "rot": [-3.0,1.0,2.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.8125,1.125],
       "rot": [1.0,-3.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.5,7.1],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.5,-2.04],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -595,23 +682,46 @@
       "subName": "_midnightpurple_g",
       "name": "Trin Bultizorg root trim - midnight purple paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_purewhite_g",
       "name": "Trin Bultizorg root trim - pure white paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_slimelime_g",
       "name": "Trin Bultizorg root trim - slime lime paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_slimelime:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_slimelime:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -622,9 +732,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -633,10 +759,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -646,126 +770,196 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-0.5,0.0],
-          "duration": 4
+          "axis": [0.0,-0.375,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "!ground_onground_2",
-          "axis": [0.0,-0.5,0.0],
-          "duration": 4
+          "variable": "!ground_onground_3",
+          "axis": [0.0,-0.375,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "!ground_onground_3",
-          "axis": [0.0,0.5,0.0],
-          "duration": 4
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "!ground_onground_2",
+          "axis": [0.0,0.375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,0.5,0.0],
-          "duration": 4
+          "axis": [0.0,0.375,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_5",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_6",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1399,7 +1593,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1741,7 +1935,6 @@
       }
     ],
     "customVariables": [],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
     "sounds": [
       {
         "name": "iv_tpp:big_fat_horn_of_doom",
@@ -1763,7 +1956,13 @@
             "forwardsDelay": -3
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       },
       {
         "name": "mts:air_brake_activating",
@@ -1774,7 +1973,13 @@
             "clampMin": 1.0,
             "clampMax": 1.0
           }
-        ]
+        ],
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       },
       {
         "name": "mts:backup_beeper",
@@ -1786,16 +1991,25 @@
             "clampMax": -1.0
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1810,8 +2024,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1826,10 +2043,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1844,8 +2064,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1863,12 +2086,29 @@
   },
   "general": {
     "description": "Mid End Heavy Dutty Dually Pickup Truck\n4 doors, 4 seats\n\nRecommended parts:\nGiant Sized Wheels\nHeavy Duty V8 Engine\nModel 1 Seats",
-    "health": 4000,
+    "health": 250,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:10","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:6","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.metal_pile_1:0:4","mts:iv_tpp.chassis_hd6_t20_hv10:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:10",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:6",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.metal_pile_1:0:4",
+        "mts:iv_tpp.chassis_hd6_t20_hv10:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:7","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.metal_pile_1:0:2"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:7",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.metal_pile_1:0:2"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_substantial.json
@@ -7,26 +7,29 @@
     "emptyMass": 3000,
     "fuelCapacity": 10000,
     "downForce": 0.6,
-    "overSteer": 2.5,
-    "underSteer": 3.0,
-    "overSteerAccel": 3.5,
-    "overSteerDecel": -3.0,
+    "overSteer": 3,
+    "underSteer": 0.5,
+    "overSteerAccel": 6,
     "axleRatio": 3.7,
     "brakingFactor": 1.5,
-    "dragCoefficient": 0.65
+    "dragCoefficient": 0.65,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.375,0.0,0.0],
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -50,13 +55,15 @@
       "pos": [0.9375,0.0,0.0],
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -66,13 +73,15 @@
       "isMirrored": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         }
       ]
     },
@@ -81,13 +90,15 @@
       "turnsWithSteer": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,5.625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         },
         {
           "animationType": "rotation",
@@ -104,13 +115,15 @@
       "isMirrored": true,
       "minValue": 1.0,
       "maxValue": 1.25,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,5.625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,10.0]
         },
         {
           "animationType": "rotation",
@@ -125,175 +138,249 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.9375,3.6875],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.9375,3.6875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.9375,3.6875],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,1.0,3.6875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fr"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.9375,2.375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.9375,2.375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,1.0,2.375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rl"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.9375,2.375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.9375,2.375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,1.0,2.375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_12"],
-        ["door_rr"]
+        [
+          "part_present_12"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,4.6875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.06,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,5,6,16,17,18,19,20,21,22,23,27,28]
     },
     {
       "pos": [0.9375,1.0625,-0.5625],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.9375,1.0625,-0.5625],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.9375,1.0625,0.5625],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-0.9375,1.0625,0.5625],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.0,2.375,3.8125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,2.375,2.75],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.625,0.46875,7.06875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.46875,7.06875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.9375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.9375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.4375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.4375,0.46875,-2.00625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.8125,-1.125],
       "rot": [1.0,-2.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.8125,0.0],
       "rot": [-3.0,1.0,2.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.8125,1.125],
       "rot": [1.0,-3.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.5,7.1],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.5,-2.04],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -533,12 +620,12 @@
       "isHookup": true,
       "connections": [
         {
-          "type": "tow_bumper",
+          "type": "tow_bumper_heavy",
           "pos": [0.0,0.3125,7.09375],
           "distance": 2.0
         },
         {
-          "type": "tow_wheel",
+          "type": "tow_wheel_heavy",
           "pos": [0.0,-0.625,5.625],
           "distance": 2.0
         }
@@ -596,65 +683,112 @@
       "subName": "_redblack_g",
       "name": "Trin Bultizorg substantial trim - red & black paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_redblack_w",
       "name": "Trin Bultizorg substantial trim - red & black paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:0:6","minecraft:wool:8:4"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:0:6",
+          "minecraft:wool:8:4"
+        ]
       ]
     },
     {
       "subName": "_redblack_r",
       "name": "Trin Bultizorg substantial trim - red & black paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:14:6","minecraft:wool:15:4"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:14:6",
+          "minecraft:wool:15:4"
+        ]
       ]
     },
     {
       "subName": "_gold_g",
       "name": "Trin Bultizorg substantial trim - gold wrap, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.wrap_roll_gold:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.wrap_roll_gold:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_gold_w",
       "name": "Trin Bultizorg substantial trim - gold wrap, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.wrap_roll_gold:0:1","minecraft:wool:0:6","minecraft:wool:8:4"]
+        [
+          "mts:iv_tpp.wrap_roll_gold:0:1",
+          "minecraft:wool:0:6",
+          "minecraft:wool:8:4"
+        ]
       ]
     },
     {
       "subName": "_gold_r",
       "name": "Trin Bultizorg substantial trim - gold wrap, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.wrap_roll_gold:0:1","minecraft:wool:14:6","minecraft:wool:15:4"]
+        [
+          "mts:iv_tpp.wrap_roll_gold:0:1",
+          "minecraft:wool:14:6",
+          "minecraft:wool:15:4"
+        ]
       ]
     },
     {
       "subName": "_forest_g",
       "name": "Trin Bultizorg substantial trim - forest paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_forest:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_forest:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_forest_w",
       "name": "Trin Bultizorg substantial trim - forest paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_forest:0:1","minecraft:wool:0:6","minecraft:wool:8:4"]
+        [
+          "mts:iv_tpp.paint_double_bucket_forest:0:1",
+          "minecraft:wool:0:6",
+          "minecraft:wool:8:4"
+        ]
       ]
     },
     {
       "subName": "_forest_r",
       "name": "Trin Bultizorg substantial trim - forest paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_forest:0:1","minecraft:wool:14:6","minecraft:wool:15:4"]
+        [
+          "mts:iv_tpp.paint_double_bucket_forest:0:1",
+          "minecraft:wool:14:6",
+          "minecraft:wool:15:4"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -665,9 +799,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -676,10 +826,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -689,126 +837,196 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-0.5,0.0],
-          "duration": 4
+          "axis": [0.0,-0.375,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "!ground_onground_2",
-          "axis": [0.0,-0.5,0.0],
-          "duration": 4
+          "variable": "!ground_onground_3",
+          "axis": [0.0,-0.375,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "!ground_onground_3",
-          "axis": [0.0,0.5,0.0],
-          "duration": 4
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "!ground_onground_2",
+          "axis": [0.0,0.375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,0.5,0.0],
-          "duration": 4
+          "axis": [0.0,0.375,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_5",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_6",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1560,7 +1778,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1808,7 +2026,6 @@
       }
     ],
     "customVariables": [],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
     "sounds": [
       {
         "name": "iv_tpp:big_fat_horn_of_doom",
@@ -1830,7 +2047,13 @@
             "forwardsDelay": -3
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       },
       {
         "name": "mts:air_brake_activating",
@@ -1841,7 +2064,13 @@
             "clampMin": 1.0,
             "clampMax": 1.0
           }
-        ]
+        ],
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       },
       {
         "name": "mts:backup_beeper",
@@ -1853,16 +2082,25 @@
             "clampMax": -1.0
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1877,8 +2115,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1893,10 +2134,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1911,8 +2155,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.25,0.125,-1.40625],
         "initialVelocity": [0.0,-1.0,0.0],
@@ -1930,12 +2177,29 @@
   },
   "general": {
     "description": "Mid End Heavy Dutty Dually Pickup Truck\n4 doors, 4 seats\n\nRecommended parts:\nGiant Sized Wheels\nHeavy Duty V10 Engine\nModel 1 Seats",
-    "health": 6000,
+    "health": 250,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:10","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:7","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.metal_pile_1:0:4","mts:iv_tpp.chassis_hd6_t20_hv10:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:10",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:7",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.metal_pile_1:0:4",
+        "mts:iv_tpp.chassis_hd6_t20_hv10:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:7","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.metal_pile_1:0:2"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:7",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.metal_pile_1:0:2"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_comfort.json
@@ -7,26 +7,29 @@
     "emptyMass": 1000,
     "fuelCapacity": 20000,
     "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 4.0,
+    "underSteer": 0.25,
+    "overSteerAccel": 8.0,
     "axleRatio": 3.9,
-    "brakingFactor": 1.3,
-    "dragCoefficient": 0.35
+    "brakingFactor": 1.6,
+    "dragCoefficient": 0.35,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -95,28 +104,42 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.9375],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.9375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.9375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.9375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
@@ -124,19 +147,30 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
@@ -144,123 +178,174 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.0,3.4375],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 0.31,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,17,18,20]
     },
     {
       "pos": [0.0,0.0,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.5,0.3125,-0.1875],
       "rot": [1.0,0.0,-2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5,0.3125,-0.1875],
       "rot": [5.0,-1.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.15625,0.3125,-0.1875],
       "rot": [0.0,2.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.15625,0.3125,-0.1875],
       "rot": [-3.0,2.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.15625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.15625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.28188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-0.84438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.5625,0.875,0.25],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
       "defaultPart": "iv_tpp:roll_bar_small_gray",
-      "types": ["generic_rollbar_single"]
+      "types": [
+        "generic_rollbar_single"
+      ]
     },
     {
       "pos": [-0.5625,0.875,0.25],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
       "defaultPart": "iv_tpp:roll_bar_small_gray",
-      "types": ["generic_rollbar_single"]
+      "types": [
+        "generic_rollbar_single"
+      ]
     }
   ],
   "collisionGroups": [
@@ -482,44 +567,75 @@
       "subName": "_midnightpurple_g",
       "name": "Trin Devom Cabrio comfort trim - Midnight Purple paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_midnightpurple_w",
       "name": "Trin Devom Cabrio comfort trim - Midnight Purple paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_g",
       "name": "Trin Devom Cabrio comfort trim - Pure Black paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_w",
       "name": "Trin Devom Cabrio comfort trim - Pure Black paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_sage_g",
       "name": "Trin Devom Cabrio comfort trim - Sage paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_sage_w",
       "name": "Trin Devom Cabrio comfort trim - Sage paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -530,8 +646,24 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
           "axis": [1.0,0.0,0.0],
           "duration": 3
         }
@@ -541,10 +673,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -554,114 +684,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1176,7 +1378,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1273,8 +1475,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1296,16 +1499,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1320,8 +1532,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1339,12 +1554,28 @@
   },
   "general": {
     "description": "Mid End Sporty Cabrio Coupe\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nTurbo Charged i5 Engine\nModel 3 Seats",
-    "health": 2000,
+    "health": 100,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1","mts:iv_tpp.roll_bar_small_gray:0:2"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1",
+        "mts:iv_tpp.roll_bar_small_gray:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_root.json
@@ -7,26 +7,29 @@
     "emptyMass": 900,
     "fuelCapacity": 15000,
     "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 4.0,
+    "underSteer": 0.25,
+    "overSteerAccel": 8.0,
     "axleRatio": 3.8,
-    "brakingFactor": 1.3,
-    "dragCoefficient": 0.35
+    "brakingFactor": 1.6,
+    "dragCoefficient": 0.35,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -95,28 +104,42 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.9375],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.9375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.9375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.9375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
@@ -124,19 +147,30 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
@@ -144,123 +178,174 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.0,3.4375],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 0.25,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,17,18,20]
     },
     {
       "pos": [0.0,0.0,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.5,0.3125,-0.1875],
       "rot": [1.0,0.0,-2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5,0.3125,-0.1875],
       "rot": [5.0,-1.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.15625,0.3125,-0.1875],
       "rot": [0.0,2.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.15625,0.3125,-0.1875],
       "rot": [-3.0,2.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.15625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.15625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.28188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-0.84438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.5625,0.875,0.25],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
       "defaultPart": "iv_tpp:roll_bar_small_gray",
-      "types": ["generic_rollbar_single"]
+      "types": [
+        "generic_rollbar_single"
+      ]
     },
     {
       "pos": [-0.5625,0.875,0.25],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
       "defaultPart": "iv_tpp:roll_bar_small_gray",
-      "types": ["generic_rollbar_single"]
+      "types": [
+        "generic_rollbar_single"
+      ]
     }
   ],
   "collisionGroups": [
@@ -482,23 +567,42 @@
       "subName": "_white_g",
       "name": "Trin Devom Cabrio root trim - White paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_tungsten_g",
       "name": "Trin Devom Cabrio root trim - Tungsten paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_steelblue_g",
       "name": "Trin Devom Cabrio root trim - Steel Blue paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_steelblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_steelblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -509,8 +613,24 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
           "axis": [1.0,0.0,0.0],
           "duration": 3
         }
@@ -520,10 +640,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -533,114 +651,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1023,7 +1213,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1228,8 +1418,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1251,16 +1442,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1275,8 +1475,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1294,12 +1497,28 @@
   },
   "general": {
     "description": "Mid End Sporty Cabrio Coupe\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nTurbo Charged i4 Engine\nModel 3 Seats",
-    "health": 1800,
+    "health": 100,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1","mts:iv_tpp.roll_bar_small_gray:0:2"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1",
+        "mts:iv_tpp.roll_bar_small_gray:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_substantial.json
@@ -7,26 +7,29 @@
     "emptyMass": 1100,
     "fuelCapacity": 25000,
     "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 4.0,
+    "underSteer": 0.25,
+    "overSteerAccel": 8.0,
     "axleRatio": 4.0,
-    "brakingFactor": 1.3,
-    "dragCoefficient": 0.35
+    "brakingFactor": 1.6,
+    "dragCoefficient": 0.35,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -95,28 +104,42 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.9375],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.9375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.9375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.9375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
@@ -124,19 +147,30 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
@@ -144,111 +178,158 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.0,3.4375],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 0.35,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,18]
     },
     {
       "pos": [0.0,0.0,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.5,0.3125,-0.1875],
       "rot": [1.0,0.0,-2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5,0.3125,-0.1875],
       "rot": [5.0,-1.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.15625,0.3125,-0.1875],
       "rot": [0.0,2.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.15625,0.3125,-0.1875],
       "rot": [-3.0,2.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.28188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-0.84438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.5625,0.875,0.25],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
       "defaultPart": "iv_tpp:roll_bar_small_chrome",
-      "types": ["generic_rollbar_single"]
+      "types": [
+        "generic_rollbar_single"
+      ]
     },
     {
       "pos": [-0.5625,0.875,0.25],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.5,
       "defaultPart": "iv_tpp:roll_bar_small_chrome",
-      "types": ["generic_rollbar_single"]
+      "types": [
+        "generic_rollbar_single"
+      ]
     }
   ],
   "collisionGroups": [
@@ -470,72 +551,119 @@
       "subName": "_firered_g",
       "name": "Trin Devom Cabrio substantial trim - Fire Red paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_firered_w",
       "name": "Trin Devom Cabrio substantial trim - Fire Red paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_firered_r",
       "name": "Trin Devom Cabrio substantial trim - Fire Red paint, Red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_g",
       "name": "Trin Devom Cabrio substantial trim - Red & Black paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_w",
       "name": "Trin Devom Cabrio substantial trim - Red & Black paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_r",
       "name": "Trin Devom Cabrio substantial trim - Red & Black paint, Red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteel_g",
       "name": "Trin Devom Cabrio substantial trim - Steel Blue & Teel paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteel_w",
       "name": "Trin Devom Cabrio substantial trim - Steel Blue & Teel paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteel_r",
       "name": "Trin Devom Cabrio substantial trim - Steel Blue & Teel paint, Red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_bubblegum_w",
       "name": "Trin Devom Cabrio substantial trim - Bubble Gum paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_bubblegum:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_bubblegum:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -546,8 +674,24 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
           "axis": [1.0,0.0,0.0],
           "duration": 3
         }
@@ -557,10 +701,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -570,114 +712,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -843,7 +1057,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1337,8 +1551,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1360,16 +1575,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1384,8 +1608,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1403,12 +1630,28 @@
   },
   "general": {
     "description": "Mid End Sporty Cabrio Coupe\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nTurbo Charged V6 Engine\nModel 3 Seats",
-    "health": 2200,
+    "health": 100,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1","mts:iv_tpp.roll_bar_small_chrome:0:2"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1",
+        "mts:iv_tpp.roll_bar_small_chrome:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_comfort.json
@@ -7,26 +7,29 @@
     "emptyMass": 1000,
     "fuelCapacity": 20000,
     "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 4.0,
+    "underSteer": 0.25,
+    "overSteerAccel": 8.0,
     "axleRatio": 3.9,
-    "brakingFactor": 1.3,
-    "dragCoefficient": 0.35
+    "brakingFactor": 1.6,
+    "dragCoefficient": 0.35,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -95,28 +104,42 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.9375],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.9375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.9375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.9375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
@@ -124,19 +147,30 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
@@ -144,119 +178,170 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.0,3.4375],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 0.31,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,19,20,22]
     },
     {
       "pos": [0.0,1.625,2.125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,1.59375,1.125],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.0,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.5,0.3125,-0.1875],
       "rot": [1.0,0.0,-2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5,0.3125,-0.1875],
       "rot": [5.0,-1.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.15625,0.3125,-0.1875],
       "rot": [0.0,2.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.15625,0.3125,-0.1875],
       "rot": [-3.0,2.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.15625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.15625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.28188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-0.84438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -463,44 +548,75 @@
       "subName": "_midnightpurple_g",
       "name": "Trin Devom comfort trim - Midnight Purple paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_midnightpurple_w",
       "name": "Trin Devom comfort trim - Midnight Purple paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_g",
       "name": "Trin Devom comfort trim - Pure Black paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_w",
       "name": "Trin Devom comfort trim - Pure Black paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_sage_g",
       "name": "Trin Devom comfort trim - Sage paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_sage_w",
       "name": "Trin Devom comfort trim - Sage paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -511,8 +627,24 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
           "axis": [1.0,0.0,0.0],
           "duration": 3
         }
@@ -522,10 +654,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -535,114 +665,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1045,7 +1247,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1319,8 +1521,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1342,16 +1545,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1366,8 +1578,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1385,12 +1600,27 @@
   },
   "general": {
     "description": "Mid End Sporty Coupe\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nTurbo Charged i5 Engine\nModel 3 Seats",
-    "health": 2000,
+    "health": 100,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_root.json
@@ -7,26 +7,29 @@
     "emptyMass": 900,
     "fuelCapacity": 15000,
     "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 4.0,
+    "underSteer": 0.25,
+    "overSteerAccel": 8.0,
     "axleRatio": 3.8,
-    "brakingFactor": 1.3,
-    "dragCoefficient": 0.35
+    "brakingFactor": 1.6,
+    "dragCoefficient": 0.35,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -95,28 +104,42 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.9375],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.9375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.9375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.9375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
@@ -124,19 +147,30 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
@@ -144,119 +178,170 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.0,3.4375],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 0.25,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,19,20,22]
     },
     {
       "pos": [0.0,1.625,2.125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,1.59375,1.125],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.0,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.5,0.3125,-0.1875],
       "rot": [1.0,0.0,-2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5,0.3125,-0.1875],
       "rot": [5.0,-1.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.15625,0.3125,-0.1875],
       "rot": [0.0,2.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.15625,0.3125,-0.1875],
       "rot": [-3.0,2.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.15625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.15625,-0.81875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.28188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-0.84438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -463,23 +548,42 @@
       "subName": "_white_g",
       "name": "Trin Devom root trim - White paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_tungsten_g",
       "name": "Trin Devom root trim - Tungsten paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_steelblue_g",
       "name": "Trin Devom root trim - Steel Blue paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_steelblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_steelblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -490,8 +594,24 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
           "axis": [1.0,0.0,0.0],
           "duration": 3
         }
@@ -501,10 +621,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -514,114 +632,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -822,7 +1012,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1262,8 +1452,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1285,16 +1476,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1309,8 +1509,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1328,12 +1531,27 @@
   },
   "general": {
     "description": "Mid End Sporty Coupe\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nTurbo Charged i4 Engine\nModel 3 Seats",
-    "health": 1800,
+    "health": 100,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:7","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:7",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:7","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:7",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_substantial.json
@@ -7,26 +7,29 @@
     "emptyMass": 1100,
     "fuelCapacity": 25000,
     "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 4.0,
+    "underSteer": 0.25,
+    "overSteerAccel": 8.0,
     "axleRatio": 4.0,
-    "brakingFactor": 1.3,
-    "dragCoefficient": 0.35
+    "brakingFactor": 1.6,
+    "dragCoefficient": 0.35,
+    "litVariable": "engine_magneto_1",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.5,
       "maxValue": 0.9,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.375],
-          "axis": [0.0,0.0,4.5]
+          "axis": [0.0,0.0,5.0]
         },
         {
           "animationType": "rotation",
@@ -95,28 +104,42 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.9375],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.9375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.9375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.9375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
@@ -124,19 +147,30 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
@@ -144,107 +178,154 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
       "maxValue": 27.0,
-      "types": ["seat","interactable_crate"],
+      "types": [
+        "seat",
+        "interactable_crate"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5,0.0,3.4375],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 0.35,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,20]
     },
     {
       "pos": [0.0,1.625,2.125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,1.59375,1.125],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.0,4.125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.5,0.3125,-0.1875],
       "rot": [1.0,0.0,-2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5,0.3125,-0.1875],
       "rot": [5.0,-1.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.15625,0.3125,-0.1875],
       "rot": [0.0,2.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.15625,0.3125,-0.1875],
       "rot": [-3.0,2.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.46875,0.15625,4.25625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.28188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-0.84438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -451,72 +532,120 @@
       "subName": "_firered_g",
       "name": "Trin Devom substantial trim - Fire Red paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_firered_w",
       "name": "Trin Devom substantial trim - Fire Red paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_firered_r",
       "name": "Trin Devom substantial trim - Fire Red paint, Red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_g",
       "name": "Trin Devom substantial trim - Red & Black paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_w",
       "name": "Trin Devom substantial trim - Red & Black paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_r",
       "name": "Trin Devom substantial trim - Red & Black paint, Red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteel_g",
       "name": "Trin Devom substantial trim - Steel Blue & Teel paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteel_w",
       "name": "Trin Devom substantial trim - Steel Blue & Teel paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteel_r",
       "name": "Trin Devom substantial trim - Steel Blue & Teel paint, Red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_customlivery1_g",
       "name": "Trin Devom substantial trim - Very Dirty Steel Blue & Teel Livery, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:8:3","minecraft:dirt:0:5"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3",
+          "minecraft:dirt:0:5"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -527,8 +656,24 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
           "axis": [1.0,0.0,0.0],
           "duration": 3
         }
@@ -538,10 +683,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -551,114 +694,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-2.5,0.0]
+          "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-8.33333E-4]
+          "axis": [0.0,-6.25E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,2.5,0.0]
+          "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -972,7 +1187,7 @@
         "emissive": true,
         "covered": true,
         "isElectric": true,
-        "color": "FFCC00",
+        "color": "FFFFA7",
         "brightnessAnimations": [
           {
             "animationType": "visibility",
@@ -1395,8 +1610,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1418,16 +1634,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1442,8 +1667,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.25,-0.15625,0.6875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1461,12 +1689,27 @@
   },
   "general": {
     "description": "Mid End Sporty Coupe\n2 doors, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nTurbo Charged V6 Engine\nModel 3 Seats",
-    "health": 2200,
+    "health": 100,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_cc4_t1_t14_i5:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_suv_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_suv_comfort.json
@@ -8,20 +8,23 @@
     "emptyMass": 1556,
     "fuelCapacity": 40000,
     "downForce": 0.45,
-    "overSteer": 1.0,
-    "underSteer": 1.5,
-    "overSteerAccel": 1.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 2.5,
+    "underSteer": 0.5,
+    "overSteerAccel": 5.0,
     "axleRatio": 3.5,
     "brakingFactor": 2.2,
-    "dragCoefficient": 0.65
+    "dragCoefficient": 0.65,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -34,8 +37,11 @@
     {
       "pos": [-1.125,0.0,0.0],
       "rot": [0.0,180.0,0.0],
+      "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +56,9 @@
       "rot": [0.0,0.0,0.0],
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -69,9 +77,12 @@
     {
       "pos": [-1.125,0.0,2.875],
       "rot": [0.0,180.0,0.0],
+      "isMirrored": true,
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -92,52 +103,76 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,-0.1875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.0,0.5625,-0.1875],
-      "types": ["seat"]
+      "types": [
+        "seat"
+      ]
     },
     {
       "pos": [0.0,0.57,-0.1875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"]
+        [
+          "part_present_8"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.34,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]
     },
@@ -146,83 +181,115 @@
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.09375,-0.88125],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.07813,3.65625],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.875,0.09375,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.875,0.09375,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.125,3.75625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.125,3.75625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.03125,1.0,3.0],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.03125,1.0,3.0],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.09375,1.125,-0.5625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.09375,1.125,-0.5625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.375,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.375,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.6875,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.6875,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     }
   ],
   "collisionGroups": [
@@ -524,7 +591,11 @@
       "name": "Trin Footpather Comfort Trim - Pure Black Paint, Gray Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -533,7 +604,11 @@
       "name": "Trin Footpather Comfort Trim - Pure Black Paint, White Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -542,7 +617,11 @@
       "name": "Trin Footpather Comfort Trim - Fire Red Paint, Gray Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -551,7 +630,11 @@
       "name": "Trin Footpather Comfort Trim - Fire Red Paint, White Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -560,7 +643,11 @@
       "name": "Trin Footpather Comfort Trim - Lapender Blue Paint, Gray Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -569,9 +656,18 @@
       "name": "Trin Footpather Comfort Trim - Lapender Blue Paint, White Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -582,9 +678,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -593,10 +705,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -606,114 +716,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     }
@@ -1170,8 +1352,9 @@
         "blendableComponents": []
       }
     ],
-    "customVariables": ["windshield"],
-    "initialVariables": ["door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "windshield"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1183,16 +1366,25 @@
             "clampMax": 1.0
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.40625,0.0625,-0.84375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1207,8 +1399,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "initialVelocity": [0.0,0.0,-1.0],
         "activeAnimations": [
@@ -1225,12 +1420,29 @@
   },
   "general": {
     "stackSize": 1,
-    "health": 3112,
+    "health": 155,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.metal_pile_4:0:2","mts:iv_tpp.chassis_ld_4_l5m_t16_i4_footpather:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.metal_pile_4:0:2",
+        "mts:iv_tpp.chassis_ld_4_l5m_t16_i4_footpather:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.metal_pile_4:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.metal_pile_4:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_suv_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_suv_root.json
@@ -6,21 +6,24 @@
     "hasTurnSignals": true,
     "emptyMass": 1521,
     "fuelCapacity": 35000,
-    "downForce": 0.45,
-    "overSteer": 1.0,
-    "underSteer": 1.5,
-    "overSteerAccel": 1.0,
-    "overSteerDecel": -1.0,
+    "downForce": 0.5,
+    "overSteer": 3.0,
+    "underSteer": 0.375,
+    "overSteerAccel": 6.0,
     "axleRatio": 3.5,
     "brakingFactor": 2.2,
-    "dragCoefficient": 0.65
+    "dragCoefficient": 0.65,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -33,8 +36,11 @@
     {
       "pos": [-1.125,0.0,0.0],
       "rot": [0.0,180.0,0.0],
+      "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -49,7 +55,9 @@
       "rot": [0.0,0.0,0.0],
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -68,9 +76,12 @@
     {
       "pos": [-1.125,0.0,2.875],
       "rot": [0.0,180.0,0.0],
+      "isMirrored": true,
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -91,52 +102,76 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,-0.1875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.0,0.5625,-0.1875],
-      "types": ["seat"]
+      "types": [
+        "seat"
+      ]
     },
     {
       "pos": [0.0,0.57,-0.1875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"]
+        [
+          "part_present_8"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.34,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,10,12,13,18,19]
     },
@@ -145,83 +180,115 @@
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.09375,-0.88125],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.07813,3.65625],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.875,0.09375,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.875,0.09375,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.125,3.75625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.125,3.75625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.03125,1.0,3.0],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.03125,1.0,3.0],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.09375,1.125,-0.5625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.09375,1.125,-0.5625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.375,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.375,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.6875,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.6875,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     }
   ],
   "collisionGroups": [
@@ -523,7 +590,11 @@
       "name": "Trin Footpather Root Trim - White Paint, Gray Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -532,7 +603,11 @@
       "name": "Trin Footpather Root Trim - Soft Green Paint, Gray Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_softgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_softgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -541,9 +616,18 @@
       "name": "Trin Footpather Root Trim - Amber Paint, Gray Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_amber:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_amber:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -554,9 +638,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -565,10 +665,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -578,114 +676,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     }
@@ -1142,8 +1312,9 @@
         "blendableComponents": []
       }
     ],
-    "customVariables": ["windshield"],
-    "initialVariables": ["door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "windshield"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1155,16 +1326,25 @@
             "clampMax": 1.0
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.40625,0.0625,-0.84375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1179,8 +1359,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "initialVelocity": [0.0,0.0,-1.0],
         "activeAnimations": [
@@ -1197,12 +1380,29 @@
   },
   "general": {
     "stackSize": 1,
-    "health": 3042,
+    "health": 155,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.metal_pile_4:0:2","mts:iv_tpp.chassis_ld_4_l5m_t16_i4_footpather:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.metal_pile_4:0:2",
+        "mts:iv_tpp.chassis_ld_4_l5m_t16_i4_footpather:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.metal_pile_4:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.metal_pile_4:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_suv_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_suv_substantial.json
@@ -8,20 +8,23 @@
     "emptyMass": 1623,
     "fuelCapacity": 40000,
     "downForce": 0.45,
-    "overSteer": 1.0,
-    "underSteer": 1.5,
-    "overSteerAccel": 1.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 2.5,
+    "underSteer": 0.5,
+    "overSteerAccel": 5.0,
     "axleRatio": 3.5,
     "brakingFactor": 2.2,
-    "dragCoefficient": 0.65
+    "dragCoefficient": 0.65,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -34,8 +37,11 @@
     {
       "pos": [-1.125,0.0,0.0],
       "rot": [0.0,180.0,0.0],
+      "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -50,7 +56,9 @@
       "rot": [0.0,0.0,0.0],
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -69,9 +77,12 @@
     {
       "pos": [-1.125,0.0,2.875],
       "rot": [0.0,180.0,0.0],
+      "isMirrored": true,
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -92,52 +103,76 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.4375,1.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.4375,1.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.4375,1.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.44,1.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,-0.1875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.0,0.5625,-0.1875],
-      "types": ["seat"]
+      "types": [
+        "seat"
+      ]
     },
     {
       "pos": [0.0,0.57,-0.1875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"]
+        [
+          "part_present_8"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.34,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]
     },
@@ -146,83 +181,115 @@
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.09375,-0.88125],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.07813,3.65625],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.875,0.09375,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.875,0.09375,-0.88125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.125,3.75625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.125,3.75625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.03125,1.0,3.0],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.03125,1.0,3.0],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.09375,1.125,-0.5625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.09375,1.125,-0.5625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.375,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.375,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.6875,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.6875,0.03125,3.75],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     }
   ],
   "collisionGroups": [
@@ -524,7 +591,11 @@
       "name": "Trin Footpather Substantial Trim - Red & Black Paint, Gray Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -533,7 +604,11 @@
       "name": "Trin Footpather Substantial Trim - Red & Black Paint, White Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -542,7 +617,11 @@
       "name": "Trin Footpather Substantial Trim - Red & Black Paint, Red Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
@@ -551,7 +630,11 @@
       "name": "Trin Footpather Substantial Trim - Tungsten & Electric Blue Paint, Gray Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -560,7 +643,11 @@
       "name": "Trin Footpather Substantial Trim - Tungsten & Electric Blue Paint, White Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -569,7 +656,11 @@
       "name": "Trin Footpather Substantial Trim - Tungsten & Electric Blue Paint, Red Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
@@ -578,7 +669,11 @@
       "name": "Trin Footpather Substantial Trim - Fire Orange Paint, Gray Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_fireorange:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_fireorange:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -587,7 +682,11 @@
       "name": "Trin Footpather Substantial Trim - Fire Orange Paint, White Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_fireorange:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_fireorange:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -596,7 +695,11 @@
       "name": "Trin Footpather Substantial Trim - Fire Orange Paint, Red Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_fireorange:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_fireorange:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
@@ -605,9 +708,19 @@
       "name": "Trin Footpather Substantial Trim - Northern Gem Livery, Red Interior",
       "description": "Mid End Leisure SUV\n2 doors, 3 seats\n\nRecommended parts:\nLarge Sized Wheels (x4)\n?I4 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["minecraft:dye:15:3","minecraft:dye:12:2","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "minecraft:dye:15:3",
+          "minecraft:dye:12:2",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -618,9 +731,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -629,10 +758,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -642,114 +769,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     }
@@ -1206,8 +1405,9 @@
         "blendableComponents": []
       }
     ],
-    "customVariables": ["windshield"],
-    "initialVariables": ["door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "windshield"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_2",
@@ -1219,16 +1419,25 @@
             "clampMax": 1.0
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.40625,0.0625,-0.84375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1243,8 +1452,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "initialVelocity": [0.0,0.0,-1.0],
         "activeAnimations": [
@@ -1261,12 +1473,31 @@
   },
   "general": {
     "stackSize": 1,
-    "health": 3246,
+    "health": 155,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.metal_pile_4:0:2","mts:iv_tpp.metal_pile_1:0:1","mts:iv_tpp.chassis_ld_4_l5m_t16_i4_footpather:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.metal_pile_4:0:2",
+        "mts:iv_tpp.metal_pile_1:0:1",
+        "mts:iv_tpp.chassis_ld_4_l5m_t16_i4_footpather:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_1:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_1:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_comfort.json
@@ -6,21 +6,24 @@
     "hasTurnSignals": true,
     "emptyMass": 1350,
     "fuelCapacity": 8000,
-    "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.5,
-    "overSteerAccel": 2.5,
-    "overSteerDecel": -0.75,
+    "downForce": 0.7,
+    "overSteer": 5.0,
+    "underSteer": 0.125,
+    "overSteerAccel": 10,
     "axleRatio": 3.6,
     "brakingFactor": 1.15,
-    "dragCoefficient": 0.36
+    "dragCoefficient": 0.36,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -36,7 +39,9 @@
       "isMirrored": true,
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -51,7 +56,9 @@
       "turnsWithSteer": true,
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -74,7 +81,9 @@
       "isMirrored": true,
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -95,84 +104,122 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.0625,1.1875],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.0625,1.1875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.0625,1.1875],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.1,1.1875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0,-1.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.9,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,11,12,14]
     },
     {
       "pos": [0.0,1.375,1.65625],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.375,0.875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.125,3.375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.3125,0.0625,-1.54688],
       "rot": [-25.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.3125,0.0625,-1.54688],
       "rot": [-25.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.90625,-0.09375,4.53188],
       "rot": [0.0,-14.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.31125,-1.532],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -379,44 +426,75 @@
       "subName": "_firered_g",
       "name": "Trin Springbok comfort trim - Fire Red paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_firered_w",
       "name": "Trin Springbok comfort trim - Fire Red paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_g",
       "name": "Trin Springbok comfort trim - Pure Black paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_w",
       "name": "Trin Springbok comfort trim - Pure Black paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_tungsten_g",
       "name": "Trin Springbok comfort trim - Tungsten paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_tungsten_w",
       "name": "Trin Springbok comfort trim - Tungsten paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -427,9 +505,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -438,10 +532,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -451,114 +543,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     }
@@ -1179,8 +1343,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1202,16 +1367,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1226,8 +1400,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1242,10 +1419,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1260,8 +1440,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1279,12 +1462,29 @@
   },
   "general": {
     "description": "Mid End 2 Seater Muscle Car\n\nRecommended parts:\nAverage Sized Wheels\nV8 Engine\nModel 1 Seats",
-    "health": 2700,
+    "health": 135,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:6","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:11","mts:iv_tpp.metal_pile_4:0:3","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_ld4_l6m_t14_v12_springbok:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:6",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:11",
+        "mts:iv_tpp.metal_pile_4:0:3",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_ld4_l6m_t14_v12_springbok:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:11","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:11",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_root.json
@@ -6,21 +6,24 @@
     "hasTurnSignals": true,
     "emptyMass": 1300,
     "fuelCapacity": 8000,
-    "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.5,
-    "overSteerAccel": 2.5,
-    "overSteerDecel": -0.75,
+    "downForce": 0.7,
+    "overSteer": 5.0,
+    "underSteer": 0.125,
+    "overSteerAccel": 10,
     "axleRatio": 3.6,
     "brakingFactor": 1.15,
-    "dragCoefficient": 0.36
+    "dragCoefficient": 0.36,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -36,7 +39,9 @@
       "isMirrored": true,
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -51,7 +56,9 @@
       "turnsWithSteer": true,
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -74,7 +81,9 @@
       "isMirrored": true,
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -95,84 +104,122 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.0625,1.1875],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.0625,1.1875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.0625,1.1875],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.1,1.1875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0,-1.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.68,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,11,12,14]
     },
     {
       "pos": [0.0,1.375,1.65625],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.375,0.875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.125,3.375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.3125,0.0625,-1.54688],
       "rot": [-25.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.3125,0.0625,-1.54688],
       "rot": [-25.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.90625,-0.09375,4.53188],
       "rot": [0.0,-14.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.31125,-1.532],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -379,23 +426,42 @@
       "subName": "_white_g",
       "name": "Trin Springbok root trim - White paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_honey_g",
       "name": "Trin Springbok root trim - Honey paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_honey:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_honey:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_spruce_g",
       "name": "Trin Springbok root trim - Spruce paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_spruce:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_spruce:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -406,9 +472,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -417,10 +499,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -430,114 +510,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     }
@@ -1158,8 +1310,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1181,16 +1334,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1205,8 +1367,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1221,10 +1386,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1239,8 +1407,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1258,12 +1429,29 @@
   },
   "general": {
     "description": "Mid End 2 Seater Muscle Car\n\nRecommended parts:\nAverage Sized Wheels\nV6 Engine\nModel 1 Seats",
-    "health": 2600,
+    "health": 135,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:6","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:11","mts:iv_tpp.metal_pile_4:0:3","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_ld4_l6m_t14_v12_springbok:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:6",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:11",
+        "mts:iv_tpp.metal_pile_4:0:3",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_ld4_l6m_t14_v12_springbok:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:11","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:11",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_substantial.json
@@ -6,21 +6,24 @@
     "hasTurnSignals": true,
     "emptyMass": 1400,
     "fuelCapacity": 10000,
-    "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.5,
-    "overSteerAccel": 2.5,
-    "overSteerDecel": -0.75,
+    "downForce": 0.7,
+    "overSteer": 5.0,
+    "underSteer": 0.125,
+    "overSteerAccel": 10,
     "axleRatio": 3.6,
     "brakingFactor": 1.15,
-    "dragCoefficient": 0.36
+    "dragCoefficient": 0.36,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -36,7 +39,9 @@
       "isMirrored": true,
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -51,7 +56,9 @@
       "turnsWithSteer": true,
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -74,7 +81,9 @@
       "isMirrored": true,
       "minValue": 0.8,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -95,84 +104,122 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.0625,1.1875],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.0625,1.1875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.0625,1.1875],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.1,1.1875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0,-1.1875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.2,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,11,12,14]
     },
     {
       "pos": [0.0,1.375,1.65625],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.375,0.875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.125,3.375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.3125,0.0625,-1.54688],
       "rot": [-25.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.3125,0.0625,-1.54688],
       "rot": [-25.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.90625,-0.09375,4.53188],
       "rot": [0.0,-14.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.31125,-1.532],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -379,72 +426,119 @@
       "subName": "_oceanblue_g",
       "name": "Trin Springbok substantial trim - Ocean Blue paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_oceanblue_w",
       "name": "Trin Springbok substantial trim - Ocean Blue paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_oceanblue_r",
       "name": "Trin Springbok substantial trim - Ocean Blue paint, Red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_midnightpurple_g",
       "name": "Trin Springbok substantial trim - Midnight Purple paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_midnightpurple_w",
       "name": "Trin Springbok substantial trim - Midnight Purple paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_midnightpurple_r",
       "name": "Trin Springbok substantial trim - Midnight Purple paint, Red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_g",
       "name": "Trin Springbok substantial trim - Red & Black paint, Gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_w",
       "name": "Trin Springbok substantial trim - Red & Black paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_r",
       "name": "Trin Springbok substantial trim - Red & Black paint, Red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_bubblegum_w",
       "name": "Trin Springbok substantial trim - Bubble Gum paint, White interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_bubblegum:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_bubblegum:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -455,9 +549,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -466,10 +576,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -479,114 +587,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     }
@@ -1207,8 +1387,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1230,16 +1411,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1254,8 +1444,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1270,10 +1463,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1288,8 +1484,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.71875,0.03125,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1307,12 +1506,29 @@
   },
   "general": {
     "description": "Mid End 2 Seater Muscle Car\n\nRecommended parts:\nAverage Sized Wheels\nV12 Engine\nModel 1 Seats",
-    "health": 2800,
+    "health": 135,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:6","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:11","mts:iv_tpp.metal_pile_4:0:3","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_ld4_l6m_t14_v12_springbok:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:6",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:11",
+        "mts:iv_tpp.metal_pile_4:0:3",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_ld4_l6m_t14_v12_springbok:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:11","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:11",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_comfort.json
@@ -8,24 +8,27 @@
     "fuelCapacity": 35000,
     "downForce": 0.65,
     "overSteer": 3.0,
-    "underSteer": 1.75,
-    "overSteerAccel": 3.0,
-    "overSteerDecel": -1.0,
+    "underSteer": 0.75,
+    "overSteerAccel": 6.0,
     "axleRatio": 3.27,
     "brakingFactor": 1.4,
-    "dragCoefficient": 0.43
+    "dragCoefficient": 0.43,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.25,0.0,0.0],
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -34,13 +37,15 @@
       "rot": [0.0,180.0,0.0],
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -48,13 +53,15 @@
       "pos": [1.25,0.0,4.9375],
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -70,13 +77,15 @@
       "turnsWithSteer": true,
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -90,41 +99,61 @@
       "pos": [0.5625,0.5,2.75],
       "dismountPos": [1.5625,0.5,2.75],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,2.75],
       "dismountPos": [-1.5625,0.5,2.75],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.5,1.4375],
       "dismountPos": [1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,1.4375],
       "dismountPos": [-1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.4375,4.3125],
       "maxValue": 0.65,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,10,11,12,13,14,15,16,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40]
     },
@@ -132,183 +161,262 @@
       "pos": [0.0,0.1875,6.09375],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.24375,-1.81875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [-1.0,0.75,-1.125],
       "rot": [0.0,0.0,0.0],
       "isSpare": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"]
+      "types": [
+        "ground_wheel"
+      ]
     },
     {
       "pos": [0.0,1.9375,2.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.96875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.03125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.125,5.96875],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.3125,0.6875,-1.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.625,0.6875,-1.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.0,0.75,0.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.21875,1.0625,-1.25],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.21875,1.0625,-1.25],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.4375,1.0625,3.86875],
       "rot": [0.0,20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.4375,1.0625,3.86875],
       "rot": [0.0,-20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.25,1.0625,3.9375],
       "rot": [0.0,30.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     }
   ],
   "collisionGroups": [
@@ -577,7 +685,11 @@
       "name": "Trin Trainingor Pick-Up Comfort Trim - Pure Black Paint, Gray Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -586,7 +698,11 @@
       "name": "Trin Trainingor Pick-Up Comfort Trim - Pure Black Paint, White Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -595,7 +711,11 @@
       "name": "Trin Trainingor Pick-Up Comfort Trim - Steel Blue Paint, Gray Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_steelblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_steelblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -604,7 +724,11 @@
       "name": "Trin Trainingor Pick-Up Comfort Trim - Steel Blue Paint, White Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_steelblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_steelblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -613,7 +737,11 @@
       "name": "Trin Trainingor Pick-Up Comfort Trim - Fire Red Paint, Gray Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -622,9 +750,20 @@
       "name": "Trin Trainingor Pick-Up Comfort Trim - Fire Red Paint, White Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_rl",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -635,9 +774,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -646,10 +801,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -659,114 +812,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1586,8 +1811,10 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS","map_light"],
-    "initialVariables": ["door_fl","door_fr","door_rl","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS",
+      "map_light"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1609,16 +1836,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1633,10 +1869,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1651,8 +1890,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1669,12 +1911,31 @@
     "modelType": "obj"
   },
   "general": {
-    "health": 3310,
+    "health": 165,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:8","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_1:0:4","mts:iv_tpp.metal_pile_4:0:2","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:8",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_1:0:4",
+        "mts:iv_tpp.metal_pile_4:0:2",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_1:0:2","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_1:0:2",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_root.json
@@ -13,19 +13,23 @@
     "overSteerDecel": -1.0,
     "axleRatio": 3.27,
     "brakingFactor": 1.4,
-    "dragCoefficient": 0.43
+    "dragCoefficient": 0.43,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.25,0.0,0.0],
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -34,13 +38,15 @@
       "rot": [0.0,180.0,0.0],
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -48,13 +54,15 @@
       "pos": [1.25,0.0,4.9375],
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -70,13 +78,15 @@
       "turnsWithSteer": true,
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -90,41 +100,61 @@
       "pos": [0.5625,0.5,2.75],
       "dismountPos": [1.5625,0.5,2.75],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,2.75],
       "dismountPos": [-1.5625,0.5,2.75],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.5,1.4375],
       "dismountPos": [1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,1.4375],
       "dismountPos": [-1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.4375,4.3125],
       "maxValue": 0.65,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,10,11,12,13,14,15,16,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40]
     },
@@ -132,183 +162,262 @@
       "pos": [0.0,0.1875,6.09375],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.24375,-1.81875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [-1.0,0.75,-1.125],
       "rot": [0.0,0.0,0.0],
       "isSpare": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"]
+      "types": [
+        "ground_wheel"
+      ]
     },
     {
       "pos": [0.0,1.9375,2.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.96875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.03125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.125,5.96875],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.3125,0.6875,-1.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.625,0.6875,-1.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.0,0.75,0.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.21875,1.0625,-1.25],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.21875,1.0625,-1.25],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.4375,1.0625,3.86875],
       "rot": [0.0,20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.4375,1.0625,3.86875],
       "rot": [0.0,-20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.25,1.0625,3.9375],
       "rot": [0.0,30.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     }
   ],
   "collisionGroups": [
@@ -577,7 +686,11 @@
       "name": "Trin Trainingor Pick-Up Root Trim - White Paint, Gray Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -586,7 +699,11 @@
       "name": "Trin Trainingor Pick-Up Root Trim - Sage Paint, Gray Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -595,9 +712,20 @@
       "name": "Trin Trainingor Pick-Up Root Trim - Chocolate Paint, Gray Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_rl",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -608,9 +736,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -619,10 +763,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -632,114 +774,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1559,8 +1773,10 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS","map_light"],
-    "initialVariables": ["door_fl","door_fr","door_rl","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS",
+      "map_light"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1582,16 +1798,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1606,10 +1831,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1624,8 +1852,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1642,12 +1873,31 @@
     "modelType": "obj"
   },
   "general": {
-    "health": 2910,
+    "health": 165,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:8","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_1:0:4","mts:iv_tpp.metal_pile_4:0:2","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:8",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_1:0:4",
+        "mts:iv_tpp.metal_pile_4:0:2",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_1:0:2","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_1:0:2",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_substantial.json
@@ -13,19 +13,23 @@
     "overSteerDecel": -1.0,
     "axleRatio": 3.27,
     "brakingFactor": 1.4,
-    "dragCoefficient": 0.43
+    "dragCoefficient": 0.43,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.25,0.0,0.0],
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -34,13 +38,15 @@
       "rot": [0.0,180.0,0.0],
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -48,13 +54,15 @@
       "pos": [1.25,0.0,4.9375],
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -70,13 +78,15 @@
       "turnsWithSteer": true,
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -90,41 +100,61 @@
       "pos": [0.5625,0.5,2.75],
       "dismountPos": [1.5625,0.5,2.75],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,2.75],
       "dismountPos": [-1.5625,0.5,2.75],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.5,1.4375],
       "dismountPos": [1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,1.4375],
       "dismountPos": [-1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.4375,4.3125],
       "maxValue": 0.65,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,10,11,12,13,14,15,16,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40]
     },
@@ -132,183 +162,262 @@
       "pos": [0.0,0.1875,6.09375],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.24375,-1.81875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [-1.0,0.75,-1.125],
       "rot": [0.0,0.0,0.0],
       "isSpare": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"]
+      "types": [
+        "ground_wheel"
+      ]
     },
     {
       "pos": [0.0,1.9375,2.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.96875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.03125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.125,5.96875],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.3125,0.6875,-1.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.625,0.6875,-1.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.0,0.75,0.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.21875,1.0625,-1.25],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.21875,1.0625,-1.25],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.4375,1.0625,3.86875],
       "rot": [0.0,20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.4375,1.0625,3.86875],
       "rot": [0.0,-20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.25,1.0625,3.9375],
       "rot": [0.0,30.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     }
   ],
   "collisionGroups": [
@@ -577,7 +686,11 @@
       "name": "Trin Trainingor Pick-Up Substantial Trim - Steel Blue & Teal Paint, Gray Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -586,7 +699,11 @@
       "name": "Trin Trainingor Pick-Up Substantial Trim - Steel Blue & Teal Paint, White Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -595,7 +712,11 @@
       "name": "Trin Trainingor Pick-Up Substantial Trim - Steel Blue & Teal Paint, Red Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
@@ -604,7 +725,11 @@
       "name": "Trin Trainingor Pick-Up Substantial Trim - Shagbark Paint, Gray Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -613,7 +738,11 @@
       "name": "Trin Trainingor Pick-Up Substantial Trim - Shagbark Paint, White Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -622,7 +751,11 @@
       "name": "Trin Trainingor Pick-Up Substantial Trim - Shagbark Paint, Red Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
@@ -631,7 +764,11 @@
       "name": "Trin Trainingor Pick-Up Substantial Trim - Oak Green Paint, Gray Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -640,7 +777,11 @@
       "name": "Trin Trainingor Pick-Up Substantial Trim - Oak Green Paint, White Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -649,9 +790,20 @@
       "name": "Trin Trainingor Pick-Up Substantial Trim - Oak Green Paint, Red Interior",
       "description": "Mid End Pick-Up\n4 Doors, 4 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_rl",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -662,9 +814,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -673,10 +841,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -686,114 +852,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1613,8 +1851,10 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS","map_light"],
-    "initialVariables": ["door_fl","door_fr","door_rl","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS",
+      "map_light"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1636,16 +1876,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1660,10 +1909,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1678,8 +1930,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1696,12 +1951,31 @@
     "modelType": "obj"
   },
   "general": {
-    "health": 3710,
+    "health": 165,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:8","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_1:0:4","mts:iv_tpp.metal_pile_4:0:2","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:8",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_1:0:4",
+        "mts:iv_tpp.metal_pile_4:0:2",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_1:0:2","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_1:0:2",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_comfort.json
@@ -13,19 +13,23 @@
     "overSteerDecel": -1.0,
     "axleRatio": 3.27,
     "brakingFactor": 1.4,
-    "dragCoefficient": 0.43
+    "dragCoefficient": 0.43,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.25,0.0,0.0],
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -34,13 +38,15 @@
       "rot": [0.0,180.0,0.0],
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -48,13 +54,15 @@
       "pos": [1.25,0.0,4.9375],
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -70,13 +78,15 @@
       "turnsWithSteer": true,
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -90,49 +100,74 @@
       "pos": [0.5625,0.5,2.75],
       "dismountPos": [1.5625,0.5,2.75],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,2.75],
       "dismountPos": [-1.5625,0.5,2.75],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.5,1.4375],
       "dismountPos": [1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,1.4375],
       "dismountPos": [-1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,0.0],
       "dismountPos": [1.0,0.5625,0.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl","door_rr"]
+        [
+          "door_rl",
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.4375,4.3125],
       "maxValue": 0.65,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,11,12,13,14,15,16,17,18,22,23,24,25,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45]
     },
@@ -140,225 +175,324 @@
       "pos": [0.0,0.1875,6.09375],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.40625,-1.75625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [-1.0,0.75,-1.125],
       "rot": [0.0,0.0,0.0],
       "isSpare": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"]
+      "types": [
+        "ground_wheel"
+      ]
     },
     {
       "pos": [0.0,1.9375,2.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.96875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.03125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,-1.03125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.125,5.96875],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.9375,0.25,-1.125],
       "rot": [0.0,2.0,-3.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.9375,0.6875,-1.0625],
       "rot": [1.0,-2.0,3.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_19"],
-        ["door_tailgate"]
+        [
+          "part_present_19"
+        ],
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.25,-1.125],
       "rot": [0.0,-1.0,2.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.6875,-1.0625],
       "rot": [-3.0,1.0,0.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_21"],
-        ["door_tailgate"]
+        [
+          "part_present_21"
+        ],
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [-0.3125,0.6875,-1.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.40625,-1.75625],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.40625,-1.75625],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.9375,0.5625],
       "maxValue": 30.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.9375,1.9375,-0.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-0.9375,1.9375,-0.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.4375,1.0625,3.86875],
       "rot": [0.0,20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.4375,1.0625,3.86875],
       "rot": [0.0,-20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.25,1.0625,3.9375],
       "rot": [0.0,30.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     }
   ],
   "collisionGroups": [
@@ -632,7 +766,11 @@
       "name": "Trin Trainingor Comfort Trim - Pure Black Paint, Gray Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -641,7 +779,11 @@
       "name": "Trin Trainingor Comfort Trim - Pure Black Paint, White Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -650,7 +792,11 @@
       "name": "Trin Trainingor Comfort Trim - Steel Blue Paint, Gray Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_steelblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_steelblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -659,7 +805,11 @@
       "name": "Trin Trainingor Comfort Trim - Steel Blue Paint, White Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_steelblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_steelblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -668,7 +818,11 @@
       "name": "Trin Trainingor Comfort Trim - Fire Red Paint, Gray Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -677,9 +831,20 @@
       "name": "Trin Trainingor Comfort Trim - Fire Red Paint, White Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_rl",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -690,9 +855,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -701,10 +882,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -714,114 +893,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1669,8 +1920,10 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS","map_light"],
-    "initialVariables": ["door_fl","door_fr","door_rl","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS",
+      "map_light"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1692,16 +1945,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1716,10 +1978,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1734,8 +1999,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1752,12 +2020,29 @@
     "modelType": "obj"
   },
   "general": {
-    "health": 3310,
+    "health": 165,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:8","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:14","mts:iv_tpp.metal_pile_4:0:2","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:8",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:14",
+        "mts:iv_tpp.metal_pile_4:0:2",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:15","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:15",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_root.json
@@ -13,19 +13,23 @@
     "overSteerDecel": -1.0,
     "axleRatio": 3.27,
     "brakingFactor": 1.4,
-    "dragCoefficient": 0.43
+    "dragCoefficient": 0.43,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.25,0.0,0.0],
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -34,13 +38,15 @@
       "rot": [0.0,180.0,0.0],
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -48,13 +54,15 @@
       "pos": [1.25,0.0,4.9375],
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -70,13 +78,15 @@
       "turnsWithSteer": true,
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -90,49 +100,74 @@
       "pos": [0.5625,0.5,2.75],
       "dismountPos": [1.5625,0.5,2.75],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,2.75],
       "dismountPos": [-1.5625,0.5,2.75],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.5,1.4375],
       "dismountPos": [1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,1.4375],
       "dismountPos": [-1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,0.0],
       "dismountPos": [1.0,0.5625,0.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl","door_rr"]
+        [
+          "door_rl",
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.4375,4.3125],
       "maxValue": 0.65,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,11,12,13,14,15,16,17,18,22,23,24,25,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45]
     },
@@ -140,225 +175,324 @@
       "pos": [0.0,0.1875,6.09375],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.40625,-1.75625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [-1.0,0.75,-1.125],
       "rot": [0.0,0.0,0.0],
       "isSpare": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"]
+      "types": [
+        "ground_wheel"
+      ]
     },
     {
       "pos": [0.0,1.9375,2.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.96875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.03125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,-1.03125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.125,5.96875],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.9375,0.25,-1.125],
       "rot": [0.0,2.0,-3.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.9375,0.6875,-1.0625],
       "rot": [1.0,-2.0,3.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_19"],
-        ["door_tailgate"]
+        [
+          "part_present_19"
+        ],
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.25,-1.125],
       "rot": [0.0,-1.0,2.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.6875,-1.0625],
       "rot": [-3.0,1.0,0.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_21"],
-        ["door_tailgate"]
+        [
+          "part_present_21"
+        ],
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [-0.3125,0.6875,-1.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.40625,-1.75625],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.40625,-1.75625],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.9375,0.5625],
       "maxValue": 30.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.9375,1.9375,-0.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-0.9375,1.9375,-0.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.4375,1.0625,3.86875],
       "rot": [0.0,20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.4375,1.0625,3.86875],
       "rot": [0.0,-20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.25,1.0625,3.9375],
       "rot": [0.0,30.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     }
   ],
   "collisionGroups": [
@@ -632,7 +766,11 @@
       "name": "Trin Trainingor Root Trim - White Paint, Gray Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -641,7 +779,11 @@
       "name": "Trin Trainingor Root Trim - Sage Paint, Gray Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -650,9 +792,20 @@
       "name": "Trin Trainingor Root Trim - Chocolate Paint, Gray Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_rl",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -663,9 +816,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -674,10 +843,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -687,114 +854,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1642,8 +1881,10 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS","map_light"],
-    "initialVariables": ["door_fl","door_fr","door_rl","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS",
+      "map_light"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1665,16 +1906,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1689,10 +1939,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1707,8 +1960,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1725,12 +1981,29 @@
     "modelType": "obj"
   },
   "general": {
-    "health": 2910,
+    "health": 165,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:8","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:13","mts:iv_tpp.metal_pile_4:0:2","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:8",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:13",
+        "mts:iv_tpp.metal_pile_4:0:2",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:15","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:15",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_substantial.json
@@ -13,19 +13,23 @@
     "overSteerDecel": -1.0,
     "axleRatio": 3.27,
     "brakingFactor": 1.4,
-    "dragCoefficient": 0.43
+    "dragCoefficient": 0.43,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.25,0.0,0.0],
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -34,13 +38,15 @@
       "rot": [0.0,180.0,0.0],
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         }
       ]
     },
@@ -48,13 +54,15 @@
       "pos": [1.25,0.0,4.9375],
       "turnsWithSteer": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -70,13 +78,15 @@
       "turnsWithSteer": true,
       "isMirrored": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.9375],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,7.0]
         },
         {
           "animationType": "rotation",
@@ -90,49 +100,74 @@
       "pos": [0.5625,0.5,2.75],
       "dismountPos": [1.5625,0.5,2.75],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,2.75],
       "dismountPos": [-1.5625,0.5,2.75],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.5,1.4375],
       "dismountPos": [1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.5,1.4375],
       "dismountPos": [-1.5625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.5625,0.0],
       "dismountPos": [1.0,0.5625,0.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl","door_rr"]
+        [
+          "door_rl",
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.4375,4.3125],
       "maxValue": 0.65,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,11,12,13,14,15,16,17,18,22,23,24,25,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45]
     },
@@ -140,225 +175,324 @@
       "pos": [0.0,0.1875,6.09375],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.40625,-1.75625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [-1.0,0.75,-1.125],
       "rot": [0.0,0.0,0.0],
       "isSpare": true,
       "maxValue": 1.1,
-      "types": ["ground_wheel"]
+      "types": [
+        "ground_wheel"
+      ]
     },
     {
       "pos": [0.0,1.9375,2.9375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.96875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.03125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,1.9375,-1.03125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice","generic_gyrophare"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice",
+        "generic_gyrophare"
+      ]
     },
     {
       "pos": [0.0,0.125,5.96875],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.9375,0.25,-1.125],
       "rot": [0.0,2.0,-3.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.9375,0.6875,-1.0625],
       "rot": [1.0,-2.0,3.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_19"],
-        ["door_tailgate"]
+        [
+          "part_present_19"
+        ],
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.25,-1.125],
       "rot": [0.0,-1.0,2.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.6875,-1.0625],
       "rot": [-3.0,1.0,0.0],
       "maxValue": 20.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_21"],
-        ["door_tailgate"]
+        [
+          "part_present_21"
+        ],
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [-0.3125,0.6875,-1.0625],
       "maxValue": 30.0,
-      "types": ["interactable_crate","interactable_barrel"],
+      "types": [
+        "interactable_crate",
+        "interactable_barrel"
+      ],
       "interactableVariables": [
-        ["door_tailgate"]
+        [
+          "door_tailgate"
+        ]
       ]
     },
     {
       "pos": [1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.09375,0.3125,-1.81875],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.40625,-1.75625],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.40625,-1.75625],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.9375,0.5625],
       "maxValue": 30.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.225,1.0,5.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-0.9375,1.9375,2.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.9375,1.9375,-0.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-0.9375,1.9375,-0.875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.28125,6.04063],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.1875,0.625,5.92188],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.25,0.8125,5.97813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.3125,1.6875,3.3125],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.4375,1.0625,3.86875],
       "rot": [0.0,20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-1.4375,1.0625,3.86875],
       "rot": [0.0,-20.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [1.25,1.0625,3.9375],
       "rot": [0.0,30.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     },
     {
       "pos": [-0.625,0.34375,-1.73438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_ledlight"]
+      "types": [
+        "generic_ledlight"
+      ]
     }
   ],
   "collisionGroups": [
@@ -632,7 +766,11 @@
       "name": "Trin Trainingor Substantial Trim - Steel Blue & Teal Paint, Gray Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -641,7 +779,11 @@
       "name": "Trin Trainingor Substantial Trim - Steel Blue & Teal Paint, White Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -650,7 +792,11 @@
       "name": "Trin Trainingor Substantial Trim - Steel Blue & Teal Paint, Red Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
@@ -659,7 +805,11 @@
       "name": "Trin Trainingor Substantial Trim - Shagbark Paint, Gray Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -668,7 +818,11 @@
       "name": "Trin Trainingor Substantial Trim - Shagbark Paint, White Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -677,7 +831,11 @@
       "name": "Trin Trainingor Substantial Trim - Shagbark Paint, Red Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
@@ -686,7 +844,11 @@
       "name": "Trin Trainingor Substantial Trim - Oak Green Paint, Gray Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
@@ -695,7 +857,11 @@
       "name": "Trin Trainingor Substantial Trim - Oak Green Paint, White Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
@@ -704,9 +870,20 @@
       "name": "Trin Trainingor Substantial Trim - Oak Green Paint, Red Interior",
       "description": "Mid End SUV\n4 Doors, 5 Seats\n\nRecommended parts:\nLarge Sized Wheels (*4)\nV8 Engine\nModel 1 Seats",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_rl",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -717,9 +894,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -728,10 +921,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -741,114 +932,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1696,8 +1959,10 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS","map_light"],
-    "initialVariables": ["door_fl","door_fr","door_rl","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS",
+      "map_light"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1719,16 +1984,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1743,10 +2017,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1761,8 +2038,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.84375,0.125,-1.5],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1779,12 +2059,29 @@
     "modelType": "obj"
   },
   "general": {
-    "health": 3710,
+    "health": 165,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:8","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:15","mts:iv_tpp.metal_pile_4:0:2","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:8",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:15",
+        "mts:iv_tpp.metal_pile_4:0:2",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.chassis_md4_l9m_t16_v8_trainingor:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:15","mts:iv_tpp.metal_pile_4:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:15",
+        "mts:iv_tpp.metal_pile_4:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_comfort.json
@@ -6,27 +6,30 @@
     "hasTurnSignals": true,
     "emptyMass": 1500,
     "fuelCapacity": 12500,
-    "downForce": 0.65,
-    "overSteer": 3.0,
-    "underSteer": 1.75,
-    "overSteerAccel": 3.0,
-    "overSteerDecel": -1.0,
+    "downForce": 0.6,
+    "overSteer": 4.0,
+    "underSteer": 0.375,
+    "overSteerAccel": 8.0,
     "axleRatio": 3.08,
     "brakingFactor": 1.4,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -95,175 +104,253 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.5],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.35,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,17,18,19,20,24]
     },
     {
       "pos": [0.0,1.5625,2.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.5625,1.46875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.09375,5.25],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.5625,-0.125,-0.8125],
       "rot": [1.0,90.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,-0.125,-0.8125],
       "rot": [-3.0,94.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,-0.3125],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,5.42188],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,-0.89063],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,-0.89063],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,4.85938],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,4.85938],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.78125,-0.03125,5.28125],
       "rot": [0.0,-5.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-1.46875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -556,44 +643,79 @@
       "subName": "_firered_g",
       "name": "Trin Urlon Sedan Compass Comfort Trim - Fire Red Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_firered_w",
       "name": "Trin Urlon Sedan Compass Comfort Trim - Fire Red Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_jetblack_g",
       "name": "Trin Urlon Sedan Compass Comfort Trim - Jet Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_jetblack_w",
       "name": "Trin Urlon Sedan Compass Comfort Trim - Jet Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_g",
       "name": "Trin Urlon Sedan Compass Comfort Trim - Lapender Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_w",
       "name": "Trin Urlon Sedan Compass Comfort Trim - Lapender Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -604,9 +726,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -615,10 +753,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -628,114 +764,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1705,8 +1913,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1728,16 +1937,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1752,8 +1970,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1768,10 +1989,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1786,8 +2010,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1805,12 +2032,27 @@
   },
   "general": {
     "description": "Mid End Sedan, Spacier Version (Compass)\n4 door, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nV6 Engine\nModel 1 Seats",
-    "health": 3000,
+    "health": 150,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:12","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:12",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:12","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:12",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_root.json
@@ -6,27 +6,30 @@
     "hasTurnSignals": true,
     "emptyMass": 1300,
     "fuelCapacity": 10000,
-    "downForce": 0.65,
-    "overSteer": 3.0,
-    "underSteer": 1.75,
-    "overSteerAccel": 3.0,
-    "overSteerDecel": -1.0,
+    "downForce": 0.6,
+    "overSteer": 4.0,
+    "underSteer": 0.375,
+    "overSteerAccel": 8.0,
     "axleRatio": 3.08,
     "brakingFactor": 1.3,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -95,175 +104,253 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.5],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.25,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,17,18,19,20,24]
     },
     {
       "pos": [0.0,1.5625,2.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.5625,1.46875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.09375,5.25],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.5625,-0.125,-0.8125],
       "rot": [1.0,90.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,-0.125,-0.8125],
       "rot": [-3.0,94.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,-0.3125],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,5.42188],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,-0.89063],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,-0.89063],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,4.85938],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,4.85938],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.78125,-0.03125,5.28125],
       "rot": [0.0,-5.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-1.46875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -556,23 +643,46 @@
       "subName": "_sage_g",
       "name": "Trin Urlon Sedan Compass Root Trim - Sage Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_purewhite_g",
       "name": "Trin Urlon Sedan Compass Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_oakgreen_g",
       "name": "Trin Urlon Sedan Compass Root Trim - Oak Green Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -583,9 +693,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -594,10 +720,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -607,114 +731,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1660,8 +1856,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1683,16 +1880,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1707,8 +1913,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1723,10 +1932,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1741,8 +1953,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1760,12 +1975,27 @@
   },
   "general": {
     "description": "Mid End Sedan, Spacier Version (Compass)\n4 door, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2600,
+    "health": 150,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:12","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:12",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:12","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:12",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_substantial.json
@@ -6,27 +6,30 @@
     "hasTurnSignals": true,
     "emptyMass": 1700,
     "fuelCapacity": 15000,
-    "downForce": 0.65,
+    "downForce": 0.7,
     "overSteer": 3.0,
-    "underSteer": 2.5,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "underSteer": 0.5,
+    "overSteerAccel": 6.0,
     "axleRatio": 3.08,
     "brakingFactor": 1.5,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -95,175 +104,253 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.5],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.65,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,10,11,12,16,17,18,19,20,21,22,23,24]
     },
     {
       "pos": [0.0,1.5625,2.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.5625,1.46875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.09375,5.25],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.5625,-0.125,-0.8125],
       "rot": [1.0,90.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,-0.125,-0.8125],
       "rot": [-3.0,94.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,-0.3125],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,5.42188],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,-0.89063],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,-0.89063],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,4.85938],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,4.85938],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.78125,-0.03125,5.28125],
       "rot": [0.0,-5.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-1.46875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -556,72 +643,124 @@
       "subName": "_steelblueandteal_g",
       "name": "Trin Urlon Sedan Compass Substantial Trim - Steel Blue & Teal Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteal_w",
       "name": "Trin Urlon Sedan Compass Substantial Trim - Steel Blue & Teal Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteal_r",
       "name": "Trin Urlon Sedan Compass Substantial Trim - Steel Blue & Teal Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_shagbark_g",
       "name": "Trin Urlon Sedan Compass Substantial Trim - Shagbark Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_shagbark_w",
       "name": "Trin Urlon Sedan Compass Substantial Trim - Shagbark Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_shagbark_r",
       "name": "Trin Urlon Sedan Compass Substantial Trim - Shagbark Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_plum_g",
       "name": "Trin Urlon Sedan Compass Substantial Trim - Plum Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_plum:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_plum:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_plum_w",
       "name": "Trin Urlon Sedan Compass Substantial Trim - Plum Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_plum:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_plum:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_plum_r",
       "name": "Trin Urlon Sedan Compass Substantial Trim - Plum Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_plum:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_plum:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_customlivery1_w",
       "name": "Trin Urlon Sedan Compass Substantial Trim - Golden Ghosts Livery, White Interior",
       "extraMaterialLists": [
-        ["minecraft:dye:1:10","minecraft:gold_ingot:0:8","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "minecraft:dye:1:10",
+          "minecraft:gold_ingot:0:8",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -632,9 +771,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -643,10 +798,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -656,114 +809,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1733,8 +1958,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1756,16 +1982,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1780,8 +2015,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1796,10 +2034,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1814,8 +2055,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1833,12 +2077,27 @@
   },
   "general": {
     "description": "Mid End Sedan, Longer Version\n4 door, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nV8 Engine\nModel 1 Seats",
-    "health": 3400,
+    "health": 150,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:12","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:12",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:12","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:12",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_comfort.json
@@ -6,27 +6,30 @@
     "hasTurnSignals": true,
     "emptyMass": 1500,
     "fuelCapacity": 12500,
-    "downForce": 0.65,
-    "overSteer": 3.0,
-    "underSteer": 1.75,
-    "overSteerAccel": 3.0,
-    "overSteerDecel": -1.0,
+    "downForce": 0.6,
+    "overSteer": 4.0,
+    "underSteer": 0.375,
+    "overSteerAccel": 8.0,
     "axleRatio": 3.08,
     "brakingFactor": 1.4,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -95,175 +104,253 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.5],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.35,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,17,18,19,20,24]
     },
     {
       "pos": [0.0,1.5625,2.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.5625,1.46875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.09375,5.25],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.5625,-0.125,-0.8125],
       "rot": [1.0,90.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,-0.125,-0.8125],
       "rot": [-3.0,94.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,-0.3125],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,5.42188],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,-0.89063],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,-0.89063],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,4.85938],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,4.85938],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.78125,-0.03125,5.28125],
       "rot": [0.0,-5.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-1.46875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -556,44 +643,79 @@
       "subName": "_firered_g",
       "name": "Trin Urlon Sedan Comfort Trim - Fire Red Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_firered_w",
       "name": "Trin Urlon Sedan Comfort Trim - Fire Red Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_jetblack_g",
       "name": "Trin Urlon Sedan Comfort Trim - Jet Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_jetblack_w",
       "name": "Trin Urlon Sedan Comfort Trim - Jet Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_g",
       "name": "Trin Urlon Sedan Comfort Trim - Lapender Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_w",
       "name": "Trin Urlon Sedan Comfort Trim - Lapender Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -604,9 +726,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -615,10 +753,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -628,114 +764,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1705,8 +1913,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1728,16 +1937,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1752,8 +1970,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1768,10 +1989,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1786,8 +2010,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1805,12 +2032,27 @@
   },
   "general": {
     "description": "Mid End Sedan, Longer Version\n4 door, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nV6 Engine\nModel 1 Seats",
-    "health": 3000,
+    "health": 150,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_root.json
@@ -6,27 +6,30 @@
     "hasTurnSignals": true,
     "emptyMass": 1300,
     "fuelCapacity": 10000,
-    "downForce": 0.65,
-    "overSteer": 3.0,
-    "underSteer": 1.75,
-    "overSteerAccel": 3.0,
-    "overSteerDecel": -1.0,
+    "downForce": 0.6,
+    "overSteer": 4.0,
+    "underSteer": 0.375,
+    "overSteerAccel": 8.0,
     "axleRatio": 3.08,
     "brakingFactor": 1.3,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -95,175 +104,253 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.5],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.25,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,17,18,19,20,24]
     },
     {
       "pos": [0.0,1.5625,2.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.5625,1.46875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.09375,5.25],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.5625,-0.125,-0.8125],
       "rot": [1.0,90.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,-0.125,-0.8125],
       "rot": [-3.0,94.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,-0.3125],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,5.42188],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,-0.89063],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,-0.89063],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,4.85938],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,4.85938],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.78125,-0.03125,5.28125],
       "rot": [0.0,-5.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-1.46875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -556,23 +643,46 @@
       "subName": "_sage_g",
       "name": "Trin Urlon Sedan Root Trim - Sage Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_purewhite_g",
       "name": "Trin Urlon Sedan Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_oakgreen_g",
       "name": "Trin Urlon Sedan Root Trim - Oak Green Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -583,9 +693,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -594,10 +720,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -607,114 +731,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1660,8 +1856,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1683,16 +1880,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1707,8 +1913,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1723,10 +1932,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1741,8 +1953,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1760,12 +1975,27 @@
   },
   "general": {
     "description": "Mid End Sedan, Longer Version\n4 door, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2600,
+    "health": 150,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_substantial.json
@@ -6,27 +6,30 @@
     "hasTurnSignals": true,
     "emptyMass": 1700,
     "fuelCapacity": 15000,
-    "downForce": 0.65,
+    "downForce": 0.7,
     "overSteer": 3.0,
-    "underSteer": 2.5,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "underSteer": 0.5,
+    "overSteerAccel": 6.0,
     "axleRatio": 3.08,
     "brakingFactor": 1.5,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -95,175 +104,253 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.5],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.65,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,10,11,12,16,17,18,19,20,21,22,23,24]
     },
     {
       "pos": [0.0,1.5625,2.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.5625,1.46875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.09375,5.25],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.5625,-0.125,-0.8125],
       "rot": [1.0,90.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,-0.125,-0.8125],
       "rot": [-3.0,94.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,-0.3125],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,5.42188],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,-0.89063],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,-0.89063],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,4.85938],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,4.85938],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.78125,-0.03125,5.28125],
       "rot": [0.0,-5.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-1.46875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -556,72 +643,123 @@
       "subName": "_steelblueandteal_g",
       "name": "Trin Urlon Sedan Substantial Trim - Steel Blue & Teal Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteal_w",
       "name": "Trin Urlon Sedan Substantial Trim - Steel Blue & Teal Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteal_r",
       "name": "Trin Urlon Sedan Substantial Trim - Steel Blue & Teal Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_shagbark_g",
       "name": "Trin Urlon Sedan Substantial Trim - Shagbark Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_shagbark_w",
       "name": "Trin Urlon Sedan Substantial Trim - Shagbark Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_shagbark_r",
       "name": "Trin Urlon Sedan Substantial Trim - Shagbark Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_plum_g",
       "name": "Trin Urlon Sedan Substantial Trim - Plum Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_plum:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_plum:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_plum_w",
       "name": "Trin Urlon Sedan Substantial Trim - Plum Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_plum:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_plum:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_plum_r",
       "name": "Trin Urlon Sedan Substantial Trim - Plum Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_plum:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_plum:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_bubblegum_w",
       "name": "Trin Urlon Sedan Substantial Trim - Bubble Gum Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_bubblegum:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_bubblegum:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -632,9 +770,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -643,10 +797,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -656,114 +808,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1733,8 +1957,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1756,16 +1981,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1780,8 +2014,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1796,10 +2033,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1814,8 +2054,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1833,12 +2076,27 @@
   },
   "general": {
     "description": "Mid End Sedan, Longer Version\n4 door, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nV8 Engine\nModel 1 Seats",
-    "health": 3400,
+    "health": 150,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_comfort.json
@@ -6,27 +6,30 @@
     "hasTurnSignals": true,
     "emptyMass": 1500,
     "fuelCapacity": 12500,
-    "downForce": 0.65,
-    "overSteer": 3.0,
-    "underSteer": 1.75,
-    "overSteerAccel": 3.0,
-    "overSteerDecel": -1.0,
+    "downForce": 0.6,
+    "overSteer": 4.0,
+    "underSteer": 0.375,
+    "overSteerAccel": 8.0,
     "axleRatio": 3.08,
     "brakingFactor": 1.4,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -95,195 +104,285 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.5],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.35,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,17,18,19,20,24]
     },
     {
       "pos": [0.0,1.5625,2.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.5625,1.46875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.09375,5.25],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.5625,-0.125,-0.8125],
       "rot": [1.0,90.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,-0.8125],
       "rot": [1.0,90.0,4.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_16"],
-        ["door_boot"]
+        [
+          "part_present_16"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,-0.125,-0.8125],
       "rot": [-3.0,94.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,-0.8125],
       "rot": [-10.0,86.0,3.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_18"],
-        ["door_boot"]
+        [
+          "part_present_18"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,-0.3125],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,5.42188],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,-0.89063],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,-0.89063],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,4.85938],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,4.85938],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.78125,-0.03125,5.28125],
       "rot": [0.0,-5.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-1.46875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -571,44 +670,79 @@
       "subName": "_firered_g",
       "name": "Trin Urlon Wagon Comfort Trim - Fire Red Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_firered_w",
       "name": "Trin Urlon Wagon Comfort Trim - Fire Red Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_jetblack_g",
       "name": "Trin Urlon Wagon Comfort Trim - Jet Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_jetblack_w",
       "name": "Trin Urlon Wagon Comfort Trim - Jet Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_g",
       "name": "Trin Urlon Wagon Comfort Trim - Lapender Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_lapenderblue_w",
       "name": "Trin Urlon Wagon Comfort Trim - Lapender Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_lapenderblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_lapenderblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -619,9 +753,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -630,10 +780,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -643,114 +791,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1725,8 +1945,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1748,16 +1969,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1772,8 +2002,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1788,10 +2021,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1806,8 +2042,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1825,12 +2064,27 @@
   },
   "general": {
     "description": "Mid End Wagon\n4 door, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nV6 Engine\nModel 1 Seats",
-    "health": 3000,
+    "health": 150,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:13","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:13",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:13","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:13",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_root.json
@@ -6,27 +6,30 @@
     "hasTurnSignals": true,
     "emptyMass": 1300,
     "fuelCapacity": 10000,
-    "downForce": 0.65,
-    "overSteer": 3.0,
-    "underSteer": 1.75,
-    "overSteerAccel": 3.0,
-    "overSteerDecel": -1.0,
+    "downForce": 0.6,
+    "overSteer": 4.0,
+    "underSteer": 0.375,
+    "overSteerAccel": 8.0,
     "axleRatio": 3.08,
     "brakingFactor": 1.3,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -95,195 +104,285 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.5],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.25,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,17,18,19,20,24]
     },
     {
       "pos": [0.0,1.5625,2.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.5625,1.46875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.09375,5.25],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.5625,-0.125,-0.8125],
       "rot": [1.0,90.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,-0.8125],
       "rot": [1.0,90.0,4.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_16"],
-        ["door_boot"]
+        [
+          "part_present_16"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,-0.125,-0.8125],
       "rot": [-3.0,94.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,-0.8125],
       "rot": [-10.0,86.0,3.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_18"],
-        ["door_boot"]
+        [
+          "part_present_18"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,-0.3125],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,5.42188],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,-0.89063],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,-0.89063],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,4.85938],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,4.85938],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.78125,-0.03125,5.28125],
       "rot": [0.0,-5.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-1.46875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -571,23 +670,46 @@
       "subName": "_sage_g",
       "name": "Trin Urlon Wagon Root Trim - Sage Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_purewhite_g",
       "name": "Trin Urlon Wagon Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_oakgreen_g",
       "name": "Trin Urlon Wagon Root Trim - Oak Green Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oakgreen:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oakgreen:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -598,9 +720,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -609,10 +747,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -622,114 +758,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1680,8 +1888,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1703,16 +1912,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1727,8 +1945,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1743,10 +1964,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1761,8 +1985,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1780,12 +2007,27 @@
   },
   "general": {
     "description": "Mid End Wagon\n4 door, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\ni4 Engine\nModel 1 Seats",
-    "health": 2600,
+    "health": 150,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:13","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:13",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:13","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:13",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_substantial.json
@@ -6,27 +6,30 @@
     "hasTurnSignals": true,
     "emptyMass": 1700,
     "fuelCapacity": 15000,
-    "downForce": 0.65,
+    "downForce": 0.7,
     "overSteer": 3.0,
-    "underSteer": 2.5,
-    "overSteerAccel": 2.0,
-    "overSteerDecel": -1.0,
+    "underSteer": 0.5,
+    "overSteerAccel": 6.0,
     "axleRatio": 3.08,
     "brakingFactor": 1.5,
-    "dragCoefficient": 0.34
+    "dragCoefficient": 0.34,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -36,13 +39,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -51,13 +56,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +81,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -95,195 +104,285 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,2.3125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,2.3125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,2.3125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,2.3125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,1.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.25,1.0],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.3,1.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.5],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.65,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,10,11,12,16,17,18,19,20,21,22,23,24]
     },
     {
       "pos": [0.0,1.5625,2.25],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.5625,1.46875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,-0.09375,5.25],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [0.5625,-0.125,-0.8125],
       "rot": [1.0,90.0,2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.25,-0.8125],
       "rot": [1.0,90.0,4.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_16"],
-        ["door_boot"]
+        [
+          "part_present_16"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,-0.125,-0.8125],
       "rot": [-3.0,94.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,-0.8125],
       "rot": [-10.0,86.0,3.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_18"],
-        ["door_boot"]
+        [
+          "part_present_18"
+        ],
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,-0.3125],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,5.42188],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.75,0.15625,-1.45313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,-0.89063],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,-0.89063],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.23438,0.3125,4.85938],
       "rot": [0.0,-90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.23438,0.3125,4.85938],
       "rot": [0.0,90.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.78125,-0.03125,5.28125],
       "rot": [0.0,-5.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.15625,-1.46875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -571,72 +670,123 @@
       "subName": "_steelblueandteal_g",
       "name": "Trin Urlon Wagon Substantial Trim - Steel Blue & Teal Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteal_w",
       "name": "Trin Urlon Wagon Substantial Trim - Steel Blue & Teal Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteal_r",
       "name": "Trin Urlon Wagon Substantial Trim - Steel Blue & Teal Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_shagbark_g",
       "name": "Trin Urlon Wagon Substantial Trim - Shagbark Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_shagbark_w",
       "name": "Trin Urlon Wagon Substantial Trim - Shagbark Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_shagbark_r",
       "name": "Trin Urlon Wagon Substantial Trim - Shagbark Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_shagbark:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_shagbark:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_plum_g",
       "name": "Trin Urlon Wagon Substantial Trim - Plum Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_plum:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_plum:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_plum_w",
       "name": "Trin Urlon Wagon Substantial Trim - Plum Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_plum:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_plum:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_plum_r",
       "name": "Trin Urlon Wagon Substantial Trim - Plum Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_plum:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_plum:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_sandstone_w",
       "name": "Trin Urlon Wagon Substantial Trim - Sandstone Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sandstone:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sandstone:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -647,9 +797,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -658,10 +824,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -671,114 +835,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,-3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.001333333]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
           "axis": [0.0,3.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1753,8 +1989,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1776,16 +2013,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1800,8 +2046,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.0625,-0.21875,0.875],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1816,10 +2065,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1834,8 +2086,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.0625,-0.21875,0.875],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1853,12 +2108,27 @@
   },
   "general": {
     "description": "Mid End Wagon\n4 door, 4 seats\n\nRecommended parts:\nAverage Sized Wheels\nV8 Engine\nModel 1 Seats",
-    "health": 3400,
+    "health": 150,
     "materialLists": [
-      ["mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1","minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:13","mts:iv_tpp.metal_pile_2:0:2"]
+      [
+        "mts:iv_tpp.chassis_ld4_l6m_t14_i4_urlon:0:1",
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:13",
+        "mts:iv_tpp.metal_pile_2:0:2"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:13","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:13",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_comfort.json
@@ -8,26 +8,29 @@
     "emptyMass": 1650,
     "fuelCapacity": 20000,
     "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 3.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 5.0,
+    "underSteer": 0.125,
+    "overSteerAccel": 10.0,
     "axleRatio": 3.5,
     "brakingFactor": 1.3,
-    "dragCoefficient": 0.25
+    "dragCoefficient": 0.25,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.1875,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -37,13 +40,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -52,13 +57,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.9375],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -75,13 +82,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.9375],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -96,133 +105,189 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.125,1.125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.125,1.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.125,1.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.13,1.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.0625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.66,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,14,15,16,20]
     },
     {
       "pos": [0.0,-0.01,5.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.875,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.875,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,-1.5375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.25,-1.5375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.5375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.3125,5.475],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.3125,5.475],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.3125,5.485],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.5,-1.51625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -453,65 +518,109 @@
       "subName": "_tungsten_g",
       "name": "Trin Flugoral comfort trim - tungsten paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_tungsten_w",
       "name": "Trin Flugoral comfort trim - tungsten paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_tungsten_r",
       "name": "Trin Flugoral comfort trim - tungsten paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_midnightpurple_g",
       "name": "Trin Flugoral comfort trim - midnight purple paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_midnightpurple_w",
       "name": "Trin Flugoral comfort trim - midnight purple paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_midnightpurple_r",
       "name": "Trin Flugoral comfort trim - midnight purple paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_g",
       "name": "Trin Flugoral comfort trim - pure black paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_w",
       "name": "Trin Flugoral comfort trim - pure black paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_r",
       "name": "Trin Flugoral comfort trim - pure black paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_hood",
+    "roof",
+    "window_l",
+    "window_r"
   ],
   "variableModifiers": [
     {
@@ -522,9 +631,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -533,10 +658,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -546,114 +669,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     }
@@ -1553,8 +1748,12 @@
         ]
       }
     ],
-    "customVariables": ["window_l","window_r","roof","EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_hood","roof","window_l","window_r"],
+    "customVariables": [
+      "window_l",
+      "window_r",
+      "roof",
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1576,16 +1775,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1600,8 +1808,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1616,10 +1827,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1634,8 +1848,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1653,12 +1870,27 @@
   },
   "general": {
     "description": "High End Sports Roadster\n2 doors, 2 seats\n\nRecommended parts:\nAverage Sized Wheels\nV10 Engine\nModel 1 Seats",
-    "health": 3300,
+    "health": 165,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_ld4_l8m_t14_v12_flugoral:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_ld4_l8m_t14_v12_flugoral:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_root.json
@@ -8,26 +8,29 @@
     "emptyMass": 1550,
     "fuelCapacity": 15000,
     "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 3.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 5.0,
+    "underSteer": 0.125,
+    "overSteerAccel": 10.0,
     "axleRatio": 3.75,
     "brakingFactor": 1.3,
-    "dragCoefficient": 0.25
+    "dragCoefficient": 0.25,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.1875,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -37,13 +40,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -52,13 +57,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.9375],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -75,13 +82,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.9375],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -96,133 +105,189 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.125,1.125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.125,1.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.125,1.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.13,1.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.0625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.65,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,14,15,16,20]
     },
     {
       "pos": [0.0,-0.01,5.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.875,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.875,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,-1.5375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.25,-1.5375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.5375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.3125,5.475],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.3125,5.475],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.3125,5.485],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.5,-1.51625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -453,44 +518,76 @@
       "subName": "_purewhite_g",
       "name": "Trin Flugoral root trim - pure white paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_purewhite_w",
       "name": "Trin Flugoral root trim - pure white paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_coldspruce_g",
       "name": "Trin Flugoral root trim - cold spruce paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_coldspruce:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_coldspruce:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_coldspruce_w",
       "name": "Trin Flugoral root trim - cold spruce paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_coldspruce:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_coldspruce:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_sage_g",
       "name": "Trin Flugoral root trim - sage paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_sage_w",
       "name": "Trin Flugoral root trim - sage paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sage:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sage:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_hood",
+    "roof",
+    "window_l",
+    "window_r"
   ],
   "variableModifiers": [
     {
@@ -501,9 +598,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -512,10 +625,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -525,114 +636,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     }
@@ -1532,8 +1715,12 @@
         ]
       }
     ],
-    "customVariables": ["window_l","window_r","roof","EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_hood","roof","window_l","window_r"],
+    "customVariables": [
+      "window_l",
+      "window_r",
+      "roof",
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1555,16 +1742,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1579,8 +1775,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1595,10 +1794,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1613,8 +1815,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1632,12 +1837,27 @@
   },
   "general": {
     "description": "High End Sports Roadster\n2 doors, 2 seats\n\nRecommended parts:\nAverage Sized Wheels\nTurbo Charged V8 Engine\nModel 1 Seats",
-    "health": 3100,
+    "health": 165,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_ld4_l8m_t14_v12_flugoral:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_ld4_l8m_t14_v12_flugoral:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_substantial.json
@@ -8,26 +8,29 @@
     "emptyMass": 1750,
     "fuelCapacity": 25000,
     "downForce": 0.75,
-    "overSteer": 2.0,
-    "underSteer": 1.0,
-    "overSteerAccel": 3.0,
-    "overSteerDecel": -1.0,
+    "overSteer": 5.0,
+    "underSteer": 0.125,
+    "overSteerAccel": 10.0,
     "axleRatio": 4.0,
     "brakingFactor": 1.3,
-    "dragCoefficient": 0.25
+    "dragCoefficient": 0.25,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.1875,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -37,13 +40,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         }
       ]
     },
@@ -52,13 +57,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.9375],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -75,13 +82,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,3.9375],
-          "axis": [0.0,0.0,3.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -96,133 +105,189 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.125,1.125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.125,1.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.125,1.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.13,1.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.0625,3.0625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.1,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,14,15,16,20]
     },
     {
       "pos": [0.0,-0.01,5.375],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.875,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.875,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.1875,-0.9375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [-0.5625,0.25,-1.5375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.25,-1.5375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.25,-1.5375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.5625,0.3125,5.475],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.5625,0.3125,5.475],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.3125,5.485],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.5,-1.51625],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -453,86 +518,142 @@
       "subName": "_redandblack_g",
       "name": "Trin Flugoral substantial trim - red & black paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_w",
       "name": "Trin Flugoral substantial trim - red & black paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_r",
       "name": "Trin Flugoral substantial trim - red & black paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_t",
       "name": "Trin Flugoral substantial trim - red & black paint, tan interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteel_g",
       "name": "Trin Flugoral substantial trim - steel blue & teel paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteel_w",
       "name": "Trin Flugoral substantial trim - steel blue & teel paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteel_r",
       "name": "Trin Flugoral substantial trim - steel blue & teel paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_steelblueandteel_t",
       "name": "Trin Flugoral substantial trim - steel blue & teel paint, tan interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_steelblueandteal:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_sunshineyellow_g",
       "name": "Trin Flugoral substantial trim - sunshine yellow paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sunshineyellow:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sunshineyellow:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_sunshineyellow_w",
       "name": "Trin Flugoral substantial trim - sunshine yellow paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sunshineyellow:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sunshineyellow:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_sunshineyellow_r",
       "name": "Trin Flugoral substantial trim - sunshine yellow paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sunshineyellow:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sunshineyellow:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_sunshineyellow_t",
       "name": "Trin Flugoral substantial trim - sunshine yellow paint, tan interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_sunshineyellow:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_sunshineyellow:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_hood",
+    "roof",
+    "window_l",
+    "window_r"
   ],
   "variableModifiers": [
     {
@@ -543,9 +664,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -554,10 +691,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -567,114 +702,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-9.09091E-4]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.5,0.0]
         }
       ]
     }
@@ -1574,8 +1781,12 @@
         ]
       }
     ],
-    "customVariables": ["window_l","window_r","roof","EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_hood","roof","window_l","window_r"],
+    "customVariables": [
+      "window_l",
+      "window_r",
+      "roof",
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1597,16 +1808,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1621,8 +1841,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1637,10 +1860,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1655,8 +1881,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.8125,0.0625,-1.5625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1674,12 +1903,27 @@
   },
   "general": {
     "description": "High End Sports Roadster\n2 doors, 2 seats\n\nRecommended parts:\nAverage Sized Wheels\nV12 Engine\nModel 1 Seats",
-    "health": 3500,
+    "health": 165,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:3","mts:iv_tpp.chassis_ld4_l8m_t14_v12_flugoral:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:3",
+        "mts:iv_tpp.chassis_ld4_l8m_t14_v12_flugoral:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:5","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:5",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_pickup_2door.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_pickup_2door.json
@@ -13,20 +13,24 @@
     "overSteerDecel": -1.0,
     "axleRatio": 3.88,
     "brakingFactor": 2.0,
-    "dragCoefficient": 0.6
+    "dragCoefficient": 0.6,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.25,0.0,0.0],
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         }
       ]
     },
@@ -36,13 +40,15 @@
       "isMirrored": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         }
       ]
     },
@@ -51,13 +57,15 @@
       "turnsWithSteer": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.0625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +82,15 @@
       "isMirrored": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.0625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         },
         {
           "animationType": "rotation",
@@ -95,47 +105,69 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.6875,0.75,1.9375],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.75,1.9375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.6875,0.75,1.9375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.8,1.9375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [1.0,1.1875,0.3125],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-1.0,1.1875,0.3125],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.0,0.3125,3.0625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.51,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,10,11,12,13,14,15,16,17,18,19,20,21,22,23]
     },
@@ -143,79 +175,111 @@
       "pos": [0.0,0.375,5.51563],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-2.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,2.4375,2.65625],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,2.4375,1.46875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.375,5.5],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.875,0.8125,5.56875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.875,0.8125,5.56875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.8125,5.56875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.125,0.28125,-1.98125],
       "rot": [0.0,-7.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.125,0.28125,-1.98125],
       "rot": [0.0,7.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.28125,1.4375,5.125],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.28125,1.4375,5.125],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.03125,2.4375,2.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.03125,2.4375,2.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     }
   ],
   "collisionGroups": [
@@ -447,191 +511,306 @@
       "subName": "_root_purewhite_g",
       "name": "Trin Gobig pickup 2 Door Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_purewhite_w",
       "name": "Trin Gobig pickup 2 Door Root Trim - Pure White Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_root_tungsten_g",
       "name": "Trin Gobig pickup 2 Door Root Trim - Tungsten Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_tungsten_w",
       "name": "Trin Gobig pickup 2 Door Root Trim - Tungsten Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_root_firered_g",
       "name": "Trin Gobig pickup 2 Door Root Trim - Fire Red Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_firered_w",
       "name": "Trin Gobig pickup 2 Door Root Trim - Fire Red Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_g",
       "name": "Trin Gobig pickup 2 Door Comfort Trim - Jet Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_w",
       "name": "Trin Gobig pickup 2 Door Comfort Trim - Jet Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_r",
       "name": "Trin Gobig pickup 2 Door Comfort Trim - Jet Black Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_g",
       "name": "Trin Gobig pickup 2 Door Comfort Trim - Ocean Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_w",
       "name": "Trin Gobig pickup 2 Door Comfort Trim - Ocean Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_r",
       "name": "Trin Gobig pickup 2 Door Comfort Trim - Ocean Blue Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_g",
       "name": "Trin Gobig pickup 2 Door Comfort Trim - Chocolate Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_w",
       "name": "Trin Gobig pickup 2 Door Comfort Trim - Chocolate Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_r",
       "name": "Trin Gobig pickup 2 Door Comfort Trim - Chocolate Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_g",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Tungsten & Electric Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_w",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Tungsten & Electric Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_r",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Tungsten & Electric Blue Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_t",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Tungsten & Electric Blue Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_g",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Red & Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_w",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Red & Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_r",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Red & Black Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_t",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Red & Black Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_g",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Midnight Purple Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_w",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Midnight Purple Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_r",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Midnight Purple Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_t",
       "name": "Trin Gobig pickup 2 Door Substantial Trim - Midnight Purple Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -642,9 +821,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -653,10 +848,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -666,114 +859,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1551,8 +1816,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1574,16 +1840,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1598,8 +1873,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1614,10 +1892,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1632,8 +1913,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1653,10 +1937,25 @@
     "description": "High End Pickup\n2 Doors, 2 Seats\n\nRecommended parts:\nGiant Sized Wheels (*4)\nHeavy V10 Engine\nModel 2 Seats",
     "health": 6580,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:8","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:4","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.chassis_hd4_l7m_t20_hv10:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:8",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:4",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.chassis_hd4_l7m_t20_hv10:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:4","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:4",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_2door.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_2door.json
@@ -13,20 +13,24 @@
     "overSteerDecel": -1.0,
     "axleRatio": 3.88,
     "brakingFactor": 1.8,
-    "dragCoefficient": 0.6
+    "dragCoefficient": 0.6,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.25,0.0,0.0],
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         }
       ]
     },
@@ -36,13 +40,15 @@
       "isMirrored": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         }
       ]
     },
@@ -51,13 +57,15 @@
       "turnsWithSteer": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.0625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +82,15 @@
       "isMirrored": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.0625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         },
         {
           "animationType": "rotation",
@@ -95,37 +105,55 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.6875,0.75,1.9375],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.75,1.9375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.6875,0.75,1.9375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.8,1.9375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,3.0625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.51,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24]
     },
@@ -133,94 +161,133 @@
       "pos": [0.0,0.375,5.51563],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-2.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,2.4375,2.65625],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,2.4375,1.28125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,2.4375,-1.21875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.375,5.5],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.875,0.8125,5.56875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.875,0.8125,5.56875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.8125,5.56875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.125,0.28125,-1.98125],
       "rot": [0.0,-7.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.125,0.28125,-1.98125],
       "rot": [0.0,7.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.28125,1.4375,5.125],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.28125,1.4375,5.125],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.03125,2.4375,2.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.03125,2.4375,2.625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.03125,2.4375,-1.0625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.03125,2.4375,-1.0625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     }
   ],
   "collisionGroups": [
@@ -471,191 +538,306 @@
       "subName": "_root_purewhite_g",
       "name": "Trin Gobig SUV 2 Door Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_purewhite_w",
       "name": "Trin Gobig SUV 2 Door Root Trim - Pure White Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_root_tungsten_g",
       "name": "Trin Gobig SUV 2 Door Root Trim - Tungsten Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_tungsten_w",
       "name": "Trin Gobig SUV 2 Door Root Trim - Tungsten Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_root_firered_g",
       "name": "Trin Gobig SUV 2 Door Root Trim - Fire Red Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_firered_w",
       "name": "Trin Gobig SUV 2 Door Root Trim - Fire Red Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_g",
       "name": "Trin Gobig SUV 2 Door Comfort Trim - Jet Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_w",
       "name": "Trin Gobig SUV 2 Door Comfort Trim - Jet Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_r",
       "name": "Trin Gobig SUV 2 Door Comfort Trim - Jet Black Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_g",
       "name": "Trin Gobig SUV 2 Door Comfort Trim - Ocean Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_w",
       "name": "Trin Gobig SUV 2 Door Comfort Trim - Ocean Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_r",
       "name": "Trin Gobig SUV 2 Door Comfort Trim - Ocean Blue Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_g",
       "name": "Trin Gobig SUV 2 Door Comfort Trim - Chocolate Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_w",
       "name": "Trin Gobig SUV 2 Door Comfort Trim - Chocolate Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_r",
       "name": "Trin Gobig SUV 2 Door Comfort Trim - Chocolate Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_g",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Tungsten & Electric Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_w",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Tungsten & Electric Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_r",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Tungsten & Electric Blue Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_t",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Tungsten & Electric Blue Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_g",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Red & Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_w",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Red & Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_r",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Red & Black Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_t",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Red & Black Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_g",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Midnight Purple Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_w",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Midnight Purple Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_r",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Midnight Purple Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_t",
       "name": "Trin Gobig SUV 2 Door Substantial Trim - Midnight Purple Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -666,9 +848,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -677,10 +875,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -690,114 +886,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1616,8 +1884,10 @@
         ]
       }
     ],
-    "customVariables": ["tailgate_window","EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "tailgate_window",
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1639,16 +1909,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1663,8 +1942,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1679,10 +1961,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1697,8 +1982,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1718,10 +2006,25 @@
     "description": "High End SUV\n2 Doors, 3 Seats\n\nRecommended parts:\nGiant Sized Wheels (*4)\nHeavy V10 Engine\nModel 2 Seats",
     "health": 6580,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:8","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:7","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.chassis_hd4_l7m_t20_hv10:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:8",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:7",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.chassis_hd4_l7m_t20_hv10:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:7","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:7",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_4door.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_4door.json
@@ -13,20 +13,24 @@
     "overSteerDecel": -1.0,
     "axleRatio": 3.88,
     "brakingFactor": 1.8,
-    "dragCoefficient": 0.6
+    "dragCoefficient": 0.6,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.25,0.0,0.0],
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         }
       ]
     },
@@ -36,13 +40,15 @@
       "isMirrored": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         }
       ]
     },
@@ -51,13 +57,15 @@
       "turnsWithSteer": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,5.625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +82,15 @@
       "isMirrored": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,5.625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         },
         {
           "animationType": "rotation",
@@ -95,113 +105,171 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.6875,1.0,3.625],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.75,3.625],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.6875,0.75,3.625],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.8,3.625],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.6875,0.75,2.4375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.6875,0.75,2.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.6875,0.8,2.4375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.75,2.4375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.6875,0.75,2.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.8,2.4375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.6875,0.75,1.25],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.6875,0.75,1.25],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.6875,0.8,1.25],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_12"],
-        ["door_rl"]
+        [
+          "part_present_12"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.75,1.25],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.6875,0.75,1.25],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.8,1.25],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_14"],
-        ["door_rr"]
+        [
+          "part_present_14"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,4.625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.51,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29]
     },
@@ -209,99 +277,141 @@
       "pos": [0.0,0.375,7.07813],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-2.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,2.4375,4.21875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,2.4375,2.84375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,2.4375,1.28125],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,2.4375,-1.21875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.375,7.0625],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.875,0.8125,7.13125],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.875,0.8125,7.13125],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.8125,7.13125],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.125,0.28125,-1.98125],
       "rot": [0.0,-7.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.125,0.28125,-1.98125],
       "rot": [0.0,7.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.28125,1.4375,6.6875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.28125,1.4375,6.6875],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.03125,2.4375,4.125],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.03125,2.4375,4.125],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [1.03125,2.4375,-1.0625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.03125,2.4375,-1.0625],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     }
   ],
   "collisionGroups": [
@@ -566,7 +676,7 @@
       "connections": [
         {
           "type": "tow_bumper_heavy",
-          "pos": [0.0,0.25,6.5625],
+          "pos": [0.0,0.25,5.0],
           "distance": 2.0
         },
         {
@@ -576,7 +686,7 @@
         },
         {
           "type": "tow_wheel_heavy",
-          "pos": [0.0,-0.625,5.625],
+          "pos": [0.0,-0.625,4.0625],
           "distance": 2.0
         }
       ]
@@ -633,191 +743,310 @@
       "subName": "_root_purewhite_g",
       "name": "Trin Gobig SUV 4 Door Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_purewhite_w",
       "name": "Trin Gobig SUV 4 Door Root Trim - Pure White Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_root_tungsten_g",
       "name": "Trin Gobig SUV 4 Door Root Trim - Tungsten Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_tungsten_w",
       "name": "Trin Gobig SUV 4 Door Root Trim - Tungsten Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_root_firered_g",
       "name": "Trin Gobig SUV 4 Door Root Trim - Fire Red Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_firered_w",
       "name": "Trin Gobig SUV 4 Door Root Trim - Fire Red Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_g",
       "name": "Trin Gobig SUV 4 Door Comfort Trim - Jet Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_w",
       "name": "Trin Gobig SUV 4 Door Comfort Trim - Jet Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_r",
       "name": "Trin Gobig SUV 4 Door Comfort Trim - Jet Black Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_g",
       "name": "Trin Gobig SUV 4 Door Comfort Trim - Ocean Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_w",
       "name": "Trin Gobig SUV 4 Door Comfort Trim - Ocean Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_r",
       "name": "Trin Gobig SUV 4 Door Comfort Trim - Ocean Blue Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_g",
       "name": "Trin Gobig SUV 4 Door Comfort Trim - Chocolate Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_w",
       "name": "Trin Gobig SUV 4 Door Comfort Trim - Chocolate Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_r",
       "name": "Trin Gobig SUV 4 Door Comfort Trim - Chocolate Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_g",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Tungsten & Electric Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_w",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Tungsten & Electric Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_r",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Tungsten & Electric Blue Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_t",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Tungsten & Electric Blue Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_g",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Red & Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_w",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Red & Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_r",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Red & Black Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_t",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Red & Black Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_g",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Midnight Purple Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_w",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Midnight Purple Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_r",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Midnight Purple Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_t",
       "name": "Trin Gobig SUV 4 Door Substantial Trim - Midnight Purple Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_fl",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -828,9 +1057,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -839,10 +1084,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -852,114 +1095,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1844,8 +2159,10 @@
         ]
       }
     ],
-    "customVariables": ["tailgate_window","EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_fl","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "tailgate_window",
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1867,16 +2184,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1891,8 +2217,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1907,10 +2236,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1925,8 +2257,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1946,10 +2281,25 @@
     "description": "High End SUV\n4 Doors, 6 Seats\n\nRecommended parts:\nGiant Sized Wheels (*4)\nHeavy V10 Engine\nModel 2 Seats",
     "health": 6980,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:9","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.chassis_hd4_l9m_t20_hv10:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:9",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.chassis_hd4_l9m_t20_hv10:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:10","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:10",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_cabrio_2door.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_cabrio_2door.json
@@ -14,20 +14,24 @@
     "overSteerDecel": -1.0,
     "axleRatio": 3.88,
     "brakingFactor": 2.0,
-    "dragCoefficient": 0.6
+    "dragCoefficient": 0.6,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.25,0.0,0.0],
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         }
       ]
     },
@@ -37,13 +41,15 @@
       "isMirrored": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         }
       ]
     },
@@ -52,13 +58,15 @@
       "turnsWithSteer": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.0625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         },
         {
           "animationType": "rotation",
@@ -75,13 +83,15 @@
       "isMirrored": true,
       "minValue": 0.99,
       "maxValue": 1.26,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.0625],
-          "axis": [0.0,0.0,7.0]
+          "axis": [0.0,0.0,12.0]
         },
         {
           "animationType": "rotation",
@@ -96,62 +106,90 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.6875,0.75,1.9375],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.75,1.9375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.6875,0.75,1.9375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.6875,0.8,1.9375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.75,0.0],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [2.0,0.75,0.0],
-      "types": ["seat"]
+      "types": [
+        "seat"
+      ]
     },
     {
       "pos": [0.0,0.8,0.0],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"]
+        [
+          "part_present_8"
+        ]
       ]
     },
     {
       "pos": [1.0,1.1875,0.3125],
       "rot": [0.0,-90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [-1.0,1.1875,0.3125],
       "rot": [0.0,90.0,0.0],
-      "types": ["seat_invisible"]
+      "types": [
+        "seat_invisible"
+      ]
     },
     {
       "pos": [0.0,0.3125,3.0625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.51,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,11,12,13,14,15,16,17,18,19,20,21]
     },
@@ -159,64 +197,89 @@
       "pos": [0.0,0.375,5.51563],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.28125,-2.01563],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,2.375,1.09375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar","generic_roofdevice"]
+      "types": [
+        "generic_lightbar",
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.375,5.5],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.875,0.8125,5.56875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.875,0.8125,5.56875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.8125,5.56875],
       "rot": [0.0,180.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.125,0.28125,-1.98125],
       "rot": [0.0,-7.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-1.125,0.28125,-1.98125],
       "rot": [0.0,7.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [1.28125,1.4375,5.125],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     },
     {
       "pos": [-1.28125,1.4375,5.125],
       "maxValue": 3.0,
-      "types": ["generic_flag_small"]
+      "types": [
+        "generic_flag_small"
+      ]
     }
   ],
   "collisionGroups": [
@@ -448,191 +511,306 @@
       "subName": "_root_purewhite_g",
       "name": "Trin Gobig SUV 2 Door Cabriolet Root Trim - Pure White Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_purewhite_w",
       "name": "Trin Gobig SUV 2 Door Cabriolet Root Trim - Pure White Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_purewhite:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_purewhite:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_root_tungsten_g",
       "name": "Trin Gobig SUV 2 Door Cabriolet Root Trim - Tungsten Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_tungsten_w",
       "name": "Trin Gobig SUV 2 Door Cabriolet Root Trim - Tungsten Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_tungsten:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_tungsten:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_root_firered_g",
       "name": "Trin Gobig SUV 2 Door Cabriolet Root Trim - Fire Red Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_root_firered_w",
       "name": "Trin Gobig SUV 2 Door Cabriolet Root Trim - Fire Red Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_firered:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_firered:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_g",
       "name": "Trin Gobig SUV 2 Door Cabriolet Comfort Trim - Jet Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_w",
       "name": "Trin Gobig SUV 2 Door Cabriolet Comfort Trim - Jet Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_jetblack_r",
       "name": "Trin Gobig SUV 2 Door Cabriolet Comfort Trim - Jet Black Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_jetblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_jetblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_g",
       "name": "Trin Gobig SUV 2 Door Cabriolet Comfort Trim - Ocean Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_w",
       "name": "Trin Gobig SUV 2 Door Cabriolet Comfort Trim - Ocean Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_oceanblue_r",
       "name": "Trin Gobig SUV 2 Door Cabriolet Comfort Trim - Ocean Blue Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_oceanblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_oceanblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_g",
       "name": "Trin Gobig SUV 2 Door Cabriolet Comfort Trim - Chocolate Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_w",
       "name": "Trin Gobig SUV 2 Door Cabriolet Comfort Trim - Chocolate Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_comfort_chocolate_r",
       "name": "Trin Gobig SUV 2 Door Cabriolet Comfort Trim - Chocolate Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_chocolate:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_chocolate:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_g",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Tungsten & Electric Blue Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_w",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Tungsten & Electric Blue Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_r",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Tungsten & Electric Blue Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_tungstenandelectricblue_t",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Tungsten & Electric Blue Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_g",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Red & Black Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_w",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Red & Black Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_r",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Red & Black Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_redandblack_t",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Red & Black Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_g",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Midnight Purple Paint, Gray Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_w",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Midnight Purple Paint, White Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_r",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Midnight Purple Paint, Red Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_substantial_midnightpurple_t",
       "name": "Trin Gobig SUV 2 Door Cabriolet Substantial Trim - Midnight Purple Paint, Tan Interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_midnightpurple:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_midnightpurple:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -643,9 +821,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -654,10 +848,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -667,114 +859,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -919,7 +1183,6 @@
     ],
     "lightObjects": [],
     "customVariables": [],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -941,16 +1204,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -965,8 +1237,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -981,10 +1256,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -999,8 +1277,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-0.78125,0.125,-1.90625],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -1020,10 +1301,25 @@
     "description": "High End SUV\n2 Doors, 3 Seats\n\nRecommended parts:\nGiant Sized Wheels (*4)\nHeavy V10 Engine\nModel 2 Seats",
     "health": 6580,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:8","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:2","mts:iv_tpp.chassis_hd4_l7m_t20_hv10:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:8",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:2",
+        "mts:iv_tpp.chassis_hd4_l7m_t20_hv10:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:4","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:1","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:4",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:1",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_comfort.json
@@ -12,21 +12,25 @@
     "overSteerAccel": 2.0,
     "overSteerDecel": -2.0,
     "axleRatio": 3.3,
-    "brakingFactor": 1.3,
-    "dragCoefficient": 0.5
+    "brakingFactor": 1.6,
+    "dragCoefficient": 0.5,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
@@ -36,13 +40,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
@@ -51,13 +57,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.25],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +82,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.25],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
@@ -95,202 +105,302 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.5,2.8125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.4375,2.8125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.5,2.8125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.44,2.8125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.625,0.4375,1.4375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.625,0.44,1.4375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.4375,1.4375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.44,1.4375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_12"],
-        ["door_rl"]
+        [
+          "part_present_12"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_14"],
-        ["door_rr"]
+        [
+          "part_present_14"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,3.875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.6,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,12,13,14,18,19,21,22]
     },
     {
       "pos": [0.0,1.9375,3.09375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,1.9375,2.84375],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,5.3125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.625,0.3125,-1.125],
       "rot": [2.0,-1.0,0.0],
       "maxValue": 1.0,
-      "types": ["interactable_crate"],
-      "customTypes": ["interactable_luggage"]
+      "types": [
+        "interactable_crate"
+      ],
+      "customTypes": [
+        "interactable_luggage"
+      ]
     },
     {
       "pos": [-0.3125,0.75,-1.125],
       "rot": [3.0,0.0,5.0],
       "maxValue": 1.0,
-      "types": ["interactable_crate"],
-      "customTypes": ["interactable_luggage"],
+      "types": [
+        "interactable_crate"
+      ],
+      "customTypes": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_20"]
+        [
+          "part_present_20"
+        ]
       ]
     },
     {
       "pos": [0.625,0.3125,-1.125],
       "rot": [-2.0,-5.0,1.0],
       "maxValue": 1.0,
-      "types": ["interactable_crate"],
-      "customTypes": ["interactable_luggage"]
+      "types": [
+        "interactable_crate"
+      ],
+      "customTypes": [
+        "interactable_luggage"
+      ]
     },
     {
       "pos": [0.3125,0.75,-1.125],
       "rot": [-3.0,1.0,0.0],
       "maxValue": 1.0,
-      "types": ["interactable_crate"],
-      "customTypes": ["interactable_luggage"],
+      "types": [
+        "interactable_crate"
+      ],
+      "customTypes": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_22"]
+        [
+          "part_present_22"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,-1.125],
       "rot": [0.0,5.0,-1.0],
       "maxValue": 1.0,
-      "types": ["interactable_crate"],
-      "customTypes": ["interactable_luggage"]
+      "types": [
+        "interactable_crate"
+      ],
+      "customTypes": [
+        "interactable_luggage"
+      ]
     },
     {
       "pos": [0.625,0.39063,-1.83438],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.39063,-1.83438],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.9375,-0.125],
       "maxValue": 1.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.28125,5.43813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.4375,-1.84438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -593,65 +703,112 @@
       "subName": "_coldspruce_g",
       "name": "Trin Large Sportail comfort trim - cold spruce paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_coldspruce:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_coldspruce:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_coldspruce_w",
       "name": "Trin Large Sportail comfort trim - cold spruce paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_coldspruce:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_coldspruce:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_coldspruce_r",
       "name": "Trin Large Sportail comfort trim - cold spruce paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_coldspruce:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_coldspruce:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_irongray_g",
       "name": "Trin Large Sportail comfort trim - iron gray paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_irongray:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_irongray:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_irongray_w",
       "name": "Trin Large Sportail comfort trim - iron gray paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_irongray:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_irongray:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_irongray_r",
       "name": "Trin Large Sportail comfort trim - iron gray paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_irongray:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_irongray:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_g",
       "name": "Trin Large Sportail comfort trim - pure black paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_w",
       "name": "Trin Large Sportail comfort trim - pure black paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_r",
       "name": "Trin Large Sportail comfort trim - pure black paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -662,9 +819,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -673,10 +846,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -686,114 +857,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1727,8 +1970,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1750,16 +1994,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1774,8 +2027,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1790,10 +2046,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1808,8 +2067,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1829,10 +2091,25 @@
     "description": "High End Full Size SUV\n4 doors, 6 seats\n\nRecommended Parts:\nLarge Sized Wheels\nV6 Engine\nModel 1 Seats",
     "health": 5600,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_lco_ladder_t6m:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_lco_ladder_t6m:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_root.json
@@ -12,21 +12,25 @@
     "overSteerAccel": 2.0,
     "overSteerDecel": -2.0,
     "axleRatio": 3.3,
-    "brakingFactor": 1.2,
-    "dragCoefficient": 0.5
+    "brakingFactor": 1.5,
+    "dragCoefficient": 0.5,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
@@ -36,13 +40,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
@@ -51,13 +57,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.25],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +82,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.25],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
@@ -95,197 +105,287 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.5,2.8125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.4375,2.8125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.5,2.8125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.44,2.8125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.625,0.4375,1.4375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.625,0.44,1.4375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.4375,1.4375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.44,1.4375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_12"],
-        ["door_rl"]
+        [
+          "part_present_12"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_14"],
-        ["door_rr"]
+        [
+          "part_present_14"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,3.875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.4,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,12,13,14,18,19,21,22]
     },
     {
       "pos": [0.0,1.9375,3.09375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,1.9375,2.84375],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,5.3125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.625,0.3125,-1.125],
       "rot": [2.0,-1.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"]
+      "types": [
+        "interactable_luggage"
+      ]
     },
     {
       "pos": [-0.3125,0.75,-1.125],
       "rot": [3.0,0.0,5.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_20"]
+        [
+          "part_present_20"
+        ]
       ]
     },
     {
       "pos": [0.625,0.3125,-1.125],
       "rot": [-2.0,-5.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"]
+      "types": [
+        "interactable_luggage"
+      ]
     },
     {
       "pos": [0.3125,0.75,-1.125],
       "rot": [-3.0,1.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_22"]
+        [
+          "part_present_22"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,-1.125],
       "rot": [0.0,5.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"]
+      "types": [
+        "interactable_luggage"
+      ]
     },
     {
       "pos": [0.625,0.39063,-1.83438],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.39063,-1.83438],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.9375,0.5],
       "maxValue": 1.0,
-      "types": ["interactable_crate"]
+      "types": [
+        "interactable_crate"
+      ]
     },
     {
       "pos": [0.0,0.28125,5.43813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.4375,-1.84438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -588,44 +688,79 @@
       "subName": "_white_g",
       "name": "Trin Large Sportail root trim - white paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_white_w",
       "name": "Trin Large Sportail root trim - white paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_slimelime_g",
       "name": "Trin Large Sportail root trim - slimelime paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_slimelime:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_slimelime:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_slimelime_w",
       "name": "Trin Large Sportail root trim - slimelime paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_slimelime:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_slimelime:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_amber_g",
       "name": "Trin Large Sportail root trim - amber paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_amber:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_amber:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_amber_w",
       "name": "Trin Large Sportail root trim - amber paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_amber:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_amber:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -636,9 +771,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -647,10 +798,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -660,114 +809,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1677,8 +1898,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1700,16 +1922,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1724,8 +1955,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1740,10 +1974,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1758,8 +1995,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1779,10 +2019,25 @@
     "description": "High End Full Size SUV\n4 doors, 6 seats\n\nRecommended Parts:\nLarge Sized Wheels\nV6 Engine\nModel 1 Seats",
     "health": 5000,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_lco_ladder_t6m:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_lco_ladder_t6m:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_substantial.json
@@ -12,21 +12,25 @@
     "overSteerAccel": 2.0,
     "overSteerDecel": -2.0,
     "axleRatio": 3.3,
-    "brakingFactor": 1.4,
-    "dragCoefficient": 0.5
+    "brakingFactor": 1.7,
+    "dragCoefficient": 0.5,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
@@ -36,13 +40,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
@@ -51,13 +57,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.25],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
@@ -74,13 +82,15 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.25],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
@@ -95,192 +105,280 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.5,2.8125],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.4375,2.8125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.5,2.8125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.44,2.8125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.625,0.4375,1.4375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.625,0.44,1.4375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_rl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.4375,1.4375],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.5,1.4375],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.44,1.4375],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_rr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rl"]
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_12"],
-        ["door_rl"]
+        [
+          "part_present_12"
+        ],
+        [
+          "door_rl"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_rr"]
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_14"],
-        ["door_rr"]
+        [
+          "part_present_14"
+        ],
+        [
+          "door_rr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,3.875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.6,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,12,13,14,18,19,20,21]
     },
     {
       "pos": [0.0,1.9375,3.09375],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,1.9375,2.84375],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,5.3125],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.625,0.3125,-1.125],
       "rot": [2.0,-1.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"]
+      "types": [
+        "interactable_luggage"
+      ]
     },
     {
       "pos": [-0.3125,0.75,-1.125],
       "rot": [3.0,0.0,5.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_20"]
+        [
+          "part_present_20"
+        ]
       ]
     },
     {
       "pos": [0.625,0.3125,-1.125],
       "rot": [-2.0,-5.0,1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"]
+      "types": [
+        "interactable_luggage"
+      ]
     },
     {
       "pos": [0.3125,0.75,-1.125],
       "rot": [-3.0,1.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_22"]
+        [
+          "part_present_22"
+        ]
       ]
     },
     {
       "pos": [0.0,0.3125,-1.125],
       "rot": [0.0,5.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"]
+      "types": [
+        "interactable_luggage"
+      ]
     },
     {
       "pos": [0.625,0.39063,-1.83438],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.39063,-1.83438],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.28125,5.43813],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.4375,-1.84438],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -583,86 +681,145 @@
       "subName": "_tungstenandelectricblue_g",
       "name": "Trin Large Sportail substantial trim - tungsten & electric blue paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_tungstenandelectricblue_w",
       "name": "Trin Large Sportail substantial trim - tungsten & electric blue paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_tungstenandelectricblue_r",
       "name": "Trin Large Sportail substantial trim - tungsten & electric blue paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_tungstenandelectricblue_t",
       "name": "Trin Large Sportail substantial trim - tungsten & electric blue paint, tan interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_g",
       "name": "Trin Large Sportail substantial trim - red & black paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_w",
       "name": "Trin Large Sportail substantial trim - red & black paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_r",
       "name": "Trin Large Sportail substantial trim - red & black paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_t",
       "name": "Trin Large Sportail substantial trim - red & black paint, tan interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_bloodred_g",
       "name": "Trin Large Sportail substantial trim - blood red paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_bloodred:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_bloodred:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_bloodred_w",
       "name": "Trin Large Sportail substantial trim - blood red paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_bloodred:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_bloodred:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_bloodred_r",
       "name": "Trin Large Sportail substantial trim - blood red paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_bloodred:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_bloodred:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_bloodred_t",
       "name": "Trin Large Sportail substantial trim - blood red paint, tan interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_bloodred:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_bloodred:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_rl",
+    "door_rl",
+    "door_rr",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -673,9 +830,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -684,10 +857,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -697,114 +868,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1762,8 +2005,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_rl","door_rl","door_rr","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1785,16 +2029,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1809,8 +2062,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1825,10 +2081,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1843,8 +2102,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1864,10 +2126,25 @@
     "description": "High End Full Size SUV\n4 doors, 6 seats\n\nRecommended Parts:\nLarge Sized Wheels\nV6 Engine\nModel 1 Seats",
     "health": 6000,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_lco_ladder_t6m:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_lco_ladder_t6m:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:9","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:9",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_comfort.json
@@ -12,21 +12,25 @@
     "overSteerAccel": 2.0,
     "overSteerDecel": -2.0,
     "axleRatio": 3.3,
-    "brakingFactor": 1.3,
-    "dragCoefficient": 0.5
+    "brakingFactor": 1.6,
+    "dragCoefficient": 0.5,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
@@ -36,56 +40,62 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
     {
-      "pos": [1.125,0.0,3.125],
+      "pos": [1.125,0.0,4.25],
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
-          "centerPoint": [-1.0E-8,0.0,3.125],
-          "axis": [0.0,0.0,5.0]
+          "centerPoint": [-1.0E-8,0.0,4.25],
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
           "variable": "rudder",
-          "centerPoint": [1.125,0.0,3.125],
+          "centerPoint": [1.125,0.0,4.25],
           "axis": [0.0,-1.0,0.0]
         }
       ]
     },
     {
-      "pos": [-1.125,0.0,3.125],
+      "pos": [-1.125,0.0,4.25],
       "rot": [0.0,180.0,0.0],
       "turnsWithSteer": true,
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
-          "centerPoint": [-1.0E-8,0.0,3.125],
-          "axis": [0.0,0.0,5.0]
+          "centerPoint": [-1.0E-8,0.0,4.25],
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
           "variable": "rudder",
-          "centerPoint": [-1.125,0.0,3.125],
+          "centerPoint": [-1.125,0.0,4.25],
           "axis": [0.0,-1.0,0.0]
         }
       ]
@@ -95,145 +105,211 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.5,1.6875],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.4375,1.6875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.5,1.6875],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.44,1.6875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.6,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,10,11,12,16,17,18,19]
     },
     {
       "pos": [0.0,1.9375,1.96875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.71875],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.1875],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.5625,0.3125,-0.9375],
       "rot": [1.0,93.0,-2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3125,-0.9375],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.375,-0.5],
       "rot": [0.0,92.0,3.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.625,0.39063,-1.45938],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.39063,-1.45938],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.28125,4.313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.4375,-1.46938],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -460,65 +536,108 @@
       "subName": "_coldspruce_g",
       "name": "Trin Small Sportail comfort trim - cold spruce paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_coldspruce:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_coldspruce:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_coldspruce_w",
       "name": "Trin Small Sportail comfort trim - cold spruce paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_coldspruce:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_coldspruce:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_coldspruce_r",
       "name": "Trin Small Sportail comfort trim - cold spruce paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_coldspruce:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_coldspruce:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_irongray_g",
       "name": "Trin Small Sportail comfort trim - iron gray paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_irongray:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_irongray:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_irongray_w",
       "name": "Trin Small Sportail comfort trim - iron gray paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_irongray:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_irongray:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_irongray_r",
       "name": "Trin Small Sportail comfort trim - iron gray paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_irongray:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_irongray:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_g",
       "name": "Trin Small Sportail comfort trim - pure black paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_w",
       "name": "Trin Small Sportail comfort trim - pure black paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_pureblack_r",
       "name": "Trin Small Sportail comfort trim - pure black paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_pureblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_pureblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -529,9 +648,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -540,10 +675,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -553,114 +686,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1530,8 +1735,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1553,16 +1759,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1577,8 +1792,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1593,10 +1811,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1611,8 +1832,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1632,10 +1856,25 @@
     "description": "High End Compact SUV\n3 door, 4 seater\n\nRecommended parts:\nLarge Sized Wheels\nV8 Engine\nModel 1 Seats",
     "health": 4200,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_lco_ladder_t5m:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_lco_ladder_t5m:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_root.json
@@ -12,21 +12,25 @@
     "overSteerAccel": 2.0,
     "overSteerDecel": -2.0,
     "axleRatio": 3.3,
-    "brakingFactor": 1.2,
-    "dragCoefficient": 0.5
+    "brakingFactor": 1.5,
+    "dragCoefficient": 0.5,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
@@ -36,56 +40,62 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
     {
-      "pos": [1.125,0.0,3.125],
+      "pos": [1.125,0.0,4.25],
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
-          "centerPoint": [-1.0E-8,0.0,3.125],
-          "axis": [0.0,0.0,5.0]
+          "centerPoint": [-1.0E-8,0.0,4.25],
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
           "variable": "rudder",
-          "centerPoint": [1.125,0.0,3.125],
+          "centerPoint": [1.125,0.0,4.25],
           "axis": [0.0,-1.0,0.0]
         }
       ]
     },
     {
-      "pos": [-1.125,0.0,3.125],
+      "pos": [-1.125,0.0,4.25],
       "rot": [0.0,180.0,0.0],
       "turnsWithSteer": true,
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
-          "centerPoint": [-1.0E-8,0.0,3.125],
-          "axis": [0.0,0.0,5.0]
+          "centerPoint": [-1.0E-8,0.0,4.25],
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
           "variable": "rudder",
-          "centerPoint": [-1.125,0.0,3.125],
+          "centerPoint": [-1.125,0.0,4.25],
           "axis": [0.0,-1.0,0.0]
         }
       ]
@@ -95,150 +105,218 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.5,1.6875],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.4375,1.6875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.5,1.6875],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.44,1.6875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.4,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,10,11,12,16,17,19,20]
     },
     {
       "pos": [0.0,1.9375,1.96875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.71875],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.1875],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.5625,0.3125,-0.9375],
       "rot": [1.0,93.0,-2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3125,-0.9375],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.375,-0.5],
       "rot": [0.0,92.0,3.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.625,0.39063,-1.45938],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.39063,-1.45938],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,1.9375,0.5],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [0.0,0.28125,4.313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.4375,-1.46938],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -465,44 +543,75 @@
       "subName": "_white_g",
       "name": "Trin Small Sportail root trim - white paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_white_w",
       "name": "Trin Small Sportail root trim - white paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_white:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_white:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_slimelime_g",
       "name": "Trin Small Sportail root trim - slimelime paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_slimelime:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_slimelime:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_slimelime_w",
       "name": "Trin Small Sportail root trim - slimelime paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_slimelime:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_slimelime:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_amber_g",
       "name": "Trin Small Sportail root trim - amber paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_amber:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_amber:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_amber_w",
       "name": "Trin Small Sportail root trim - amber paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_amber:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_amber:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -513,9 +622,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -524,10 +649,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -537,114 +660,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1490,8 +1685,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1513,16 +1709,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1537,8 +1742,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1553,10 +1761,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1571,8 +1782,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1592,10 +1806,25 @@
     "description": "High End Compact SUV\n3 door, 4 seater\n\nRecommended parts:\nLarge Sized Wheels\nV6 Engine\nModel 1 Seats",
     "health": 3800,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_lco_ladder_t5m:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_lco_ladder_t5m:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_substantial.json
@@ -12,21 +12,25 @@
     "overSteerAccel": 2.0,
     "overSteerDecel": -2.0,
     "axleRatio": 3.3,
-    "brakingFactor": 1.4,
-    "dragCoefficient": 0.5
+    "brakingFactor": 1.7,
+    "dragCoefficient": 0.5,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
       "pos": [1.125,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
@@ -36,56 +40,62 @@
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,5.0]
+          "axis": [0.0,0.0,8.0]
         }
       ]
     },
     {
-      "pos": [1.125,0.0,3.125],
+      "pos": [1.125,0.0,4.25],
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
-          "centerPoint": [-1.0E-8,0.0,3.125],
-          "axis": [0.0,0.0,5.0]
+          "centerPoint": [-1.0E-8,0.0,4.25],
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
           "variable": "rudder",
-          "centerPoint": [1.125,0.0,3.125],
+          "centerPoint": [1.125,0.0,4.25],
           "axis": [0.0,-1.0,0.0]
         }
       ]
     },
     {
-      "pos": [-1.125,0.0,3.125],
+      "pos": [-1.125,0.0,4.25],
       "rot": [0.0,180.0,0.0],
       "turnsWithSteer": true,
       "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 1.0,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
-          "centerPoint": [-1.0E-8,0.0,3.125],
-          "axis": [0.0,0.0,5.0]
+          "centerPoint": [-1.0E-8,0.0,4.25],
+          "axis": [0.0,0.0,8.0]
         },
         {
           "animationType": "rotation",
           "variable": "rudder",
-          "centerPoint": [-1.125,0.0,3.125],
+          "centerPoint": [-1.125,0.0,4.25],
           "axis": [0.0,-1.0,0.0]
         }
       ]
@@ -95,145 +105,211 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.625,0.5,1.6875],
       "isController": true,
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.4375,1.6875],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.625,0.5,1.6875],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.625,0.44,1.6875],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_6"],
-        ["door_fr"]
+        [
+          "part_present_6"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fl"]
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_8"],
-        ["door_fl"]
+        [
+          "part_present_8"
+        ],
+        [
+          "door_fl"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.5625,0.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.4375,0.5,0.125],
-      "types": ["seat"],
+      "types": [
+        "seat"
+      ],
       "interactableVariables": [
-        ["door_fr"]
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [-0.4375,0.57,0.125],
       "rot": [0.0,90.0,0.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["part_present_10"],
-        ["door_fr"]
+        [
+          "part_present_10"
+        ],
+        [
+          "door_fr"
+        ]
       ]
     },
     {
       "pos": [0.0,0.25,2.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.6,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "interactableVariables": [
-        ["door_hood"]
+        [
+          "door_hood"
+        ]
       ],
       "linkedParts": [1,2,3,4,10,11,12,16,17,18,19]
     },
     {
       "pos": [0.0,1.9375,1.96875],
       "maxValue": 3.0,
-      "types": ["generic_lightbar"]
+      "types": [
+        "generic_lightbar"
+      ]
     },
     {
       "pos": [0.0,1.9375,1.71875],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,0.15625,4.1875],
       "maxValue": 2.0,
-      "types": ["generic_bullbar"]
+      "types": [
+        "generic_bullbar"
+      ]
     },
     {
       "pos": [-0.5625,0.3125,-0.9375],
       "rot": [1.0,93.0,-2.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.5625,0.3125,-0.9375],
       "rot": [2.0,87.0,-1.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.0,0.375,-0.5],
       "rot": [0.0,92.0,3.0],
       "maxValue": 2.0,
-      "types": ["interactable_luggage"],
+      "types": [
+        "interactable_luggage"
+      ],
       "interactableVariables": [
-        ["door_boot"]
+        [
+          "door_boot"
+        ]
       ]
     },
     {
       "pos": [0.625,0.39063,-1.45938],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [-0.625,0.39063,-1.45938],
       "rot": [0.0,0.0,0.0],
       "maxValue": 1.0,
-      "types": ["generic_bumpersticker"]
+      "types": [
+        "generic_bumpersticker"
+      ]
     },
     {
       "pos": [0.0,0.28125,4.313],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     },
     {
       "pos": [0.0,0.4375,-1.46938],
       "rot": [0.0,180.0,0.0],
       "maxValue": 3.0,
       "defaultPart": "iv_tpp:plate_gramados",
-      "types": ["generic_licenseplate_us","generic_licenseplate_euro"]
+      "types": [
+        "generic_licenseplate_us",
+        "generic_licenseplate_euro"
+      ]
     }
   ],
   "collisionGroups": [
@@ -460,86 +536,141 @@
       "subName": "_tungstenandelectricblue_g",
       "name": "Trin Small Sportail substantial trim - tungsten & electric blue paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_tungstenandelectricblue_w",
       "name": "Trin Small Sportail substantial trim - tungsten & electric blue paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_tungstenandelectricblue_r",
       "name": "Trin Small Sportail substantial trim - tungsten & electric blue paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_tungstenandelectricblue_t",
       "name": "Trin Small Sportail substantial trim - tungsten & electric blue paint, tan interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_tungstenandelectricblue:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_g",
       "name": "Trin Small Sportail substantial trim - red & black paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_w",
       "name": "Trin Small Sportail substantial trim - red & black paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_r",
       "name": "Trin Small Sportail substantial trim - red & black paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_redandblack_t",
       "name": "Trin Small Sportail substantial trim - red & black paint, tan interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_double_bucket_redandblack:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_double_bucket_redandblack:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_bloodred_g",
       "name": "Trin Small Sportail substantial trim - blood red paint, gray interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_bloodred:0:1","minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "mts:iv_tpp.paint_bucket_bloodred:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     },
     {
       "subName": "_bloodred_w",
       "name": "Trin Small Sportail substantial trim - blood red paint, white interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_bloodred:0:1","minecraft:wool:8:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_bloodred:0:1",
+          "minecraft:wool:8:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     },
     {
       "subName": "_bloodred_r",
       "name": "Trin Small Sportail substantial trim - blood red paint, red interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_bloodred:0:1","minecraft:wool:7:2","minecraft:wool:14:3"]
+        [
+          "mts:iv_tpp.paint_bucket_bloodred:0:1",
+          "minecraft:wool:7:2",
+          "minecraft:wool:14:3"
+        ]
       ]
     },
     {
       "subName": "_bloodred_t",
       "name": "Trin Small Sportail substantial trim - blood red paint, tan interior",
       "extraMaterialLists": [
-        ["mts:iv_tpp.paint_bucket_bloodred:0:1","minecraft:wool:4:2","minecraft:wool:0:3"]
+        [
+          "mts:iv_tpp.paint_bucket_bloodred:0:1",
+          "minecraft:wool:4:2",
+          "minecraft:wool:0:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fl",
+    "door_fr",
+    "door_fr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -550,9 +681,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -561,10 +708,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -574,114 +719,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-7.5E-4,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.00375,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }
@@ -1550,8 +1767,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fl","door_fr","door_fr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tpp:horn_1",
@@ -1573,16 +1791,25 @@
             "forwardsDelay": -2
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1597,8 +1824,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.1875,-0.0625,0.75],
         "initialVelocity": [1.0,0.0,0.0],
@@ -1613,10 +1843,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1631,8 +1864,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.1875,-0.0625,0.75],
         "initialVelocity": [-1.0,0.0,0.0],
@@ -1652,10 +1888,25 @@
     "description": "High End Compact SUV\n3 door, 4 seater\n\nRecommended parts:\nLarge Sized Wheels\nV8 Engine\nModel 1 Seats",
     "health": 4600,
     "materialLists": [
-      ["minecraft:iron_ingot:0:16","minecraft:iron_block:0:5","minecraft:glowstone_dust:0:16","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_2:0:1","mts:iv_tpp.chassis_lco_ladder_t5m:0:1"]
+      [
+        "minecraft:iron_ingot:0:16",
+        "minecraft:iron_block:0:5",
+        "minecraft:glowstone_dust:0:16",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_2:0:1",
+        "mts:iv_tpp.chassis_lco_ladder_t5m:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:8","minecraft:iron_block:0:2","minecraft:glowstone_dust:0:8","minecraft:glass_pane:0:8","mts:iv_tpp.metal_pile_2:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:8",
+        "minecraft:iron_block:0:2",
+        "minecraft:glowstone_dust:0:8",
+        "minecraft:glass_pane:0:8",
+        "mts:iv_tpp.metal_pile_2:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/trin_base_JSON.json.example
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/trin_base_JSON.json.example
@@ -8,12 +8,12 @@
 		"fuelCapacity": 40000,
 		"axleRatio": 3.08,
 		"dragCoefficient": 0.34,
-		"overSteer": 3,
-		"underSteer": 1.75,
-		"overSteerAccel": 3,
-		"overSteerDecel": -1,
 		"brakingFactor": 1.4,
-		"downForce": 0.65
+		"downForce": 0.65,//How easily the vehicle can turn at higher speeds, this is NOT actually conventional downforce though and is unrelated to dragCoefficient/weight/etc.
+		"overSteer": 3,//How much this vehicle wants to throw its butt out when turning
+		"underSteer": 1.75,//How much this vehicle will resist from throwing out its butt when turning
+		"overSteerAccel": 3,//Added (or subtracted) oversteer on acceleration
+		"overSteerDecel": 0//Added (or subtracted) oversteer on deceleration
 	},
 	"parts": [
 		{//wheel RL (rear left)
@@ -172,28 +172,42 @@
 	],
   "variableModifiers": [
     {
-      "variable": "throttle",//Stick shift logic
-      "animations": [
-          {
-            "animationType": "visibility",
-            "variable": "engine_isautomatic_1"//Checks if engine is actually stick shift
-          },
-          {
-            "animationType": "translation",
-            "variable": "!engine_clutching_1",//Checks if engine is shifting without necessarily being shifting up or down
-            "axis": [1,0,0],//"Multiplies" throttle amount by this, which makes throttle either equal to throttle or 0
-            "duration": 3//Smooths out the animation for better sound behavior
-          }
-        ]
-      },
-      {//Makes braking smooth unless parking brake is on (otherwise it would break the p_brake)
-      "variable": "brakingFactor",
+      "variable": "throttle",//Shift stick logic, disables when engine is automatic or "dualclutch" automatic
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "engine_isautomatic_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
+          "duration": 3
+        }
+      ]
+    },
+    {
+      "variable": "brakingFactor",//Smoother braking for controller compatibility
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -202,115 +216,187 @@
         }
       ]
     },
-    {//How much the rear left wheel will roll
-      "variable": "rlBodyroll",
-      "minValue": -1.0,
-      "maxValue": 1.0,
+    {
+      "variable": "axleRatio",//Revs up engine when drifting or sliding
       "animations": [
         {
-          "animationType": "translation",
-          "variable": "turn_indicator",//Steering Bodyroll
-          "axis": [0.0,0.0,-0.002]//Divide 1 by a large hundredths number for best results (1÷400 to 1÷1000, higher dividing numbers make a more stiff/less responsive suspension.)
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
         },
         {
           "animationType": "translation",
-          "variable": "!ground_onground_1",//Drops suspension when this wheel is in the air
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
-        },
-        {
-          "animationType": "inhibitor",
-          "variable": "speed",//Inhibitor to keep vehicle from being very bouncy at a standstill
-          "clampMax": 0.125
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
         },
         {
           "animationType": "translation",
-          "variable": "acceleration",//Acceleration Bodyroll
-          "axis": [0.0,4.0,0]
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
         }
       ]
     },
-    {//How much the rear right wheel will roll
-      "variable": "rrBodyroll",
-      "minValue": -1.0,
-      "maxValue": 1.0,
+    {
+      "variable": "rlBodyroll",//How much the rear left wheel will roll
+      "minValue": -1.0,//Not inverted
+      "maxValue": 0.5,//Half value to prevent wheel from clipping into the wheel well
       "animations": [
         {
           "animationType": "translation",
-          "variable": "turn_indicator",//Steering Bodyroll
-          "axis": [0.0,0.0,-0.002]//Divide 1 by a large hundredths number for best results (1÷400 to 1÷1000, higher dividing numbers make a more stiff/less responsive suspension.)
+          "variable": "turn_indicator",
+          "axis": [0.0,-0.001,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "!ground_onground_2",//Drops suspension when this wheel is in the air
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
-        },
-        {
-          "animationType": "inhibitor",
-          "variable": "speed",//Inhibitor to keep vehicle from being very bouncy at a standstill
-          "clampMax": 0.125
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "acceleration",//Acceleration Bodyroll
-          "axis": [0.0,-4.0,0]
+          "variable": "!ground_onground_1",
+          "axis": [0.0,-1.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "acceleration",
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
-    {//How much the front left wheel will roll
-      "variable": "flBodyroll",
-      "minValue": -1.0,
-      "maxValue": 1.0,
+    {
+      "variable": "rrBodyroll",//How much the rear right wheel will roll
+      "minValue": -0.5,//Half value to prevent wheel from clipping into the wheel well
+      "maxValue": 1.0,//Inverted for mirroring
       "animations": [
         {
           "animationType": "translation",
-          "variable": "turn_indicator",//Steering Bodyroll
-          "axis": [0.0,0.0,-0.002]//Divide 1 by a large hundredths number for best results (1÷400 to 1÷1000, higher dividing numbers make a more stiff/less responsive suspension.)
+          "variable": "turn_indicator",
+          "axis": [0.0,-0.001,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "!ground_onground_3",//Drops suspension when this wheel is in the air
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
-        },
-        {
-          "animationType": "inhibitor",
-          "variable": "speed",//Inhibitor to keep vehicle from being very bouncy at a standstill
-          "clampMax": 0.125
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "acceleration",//Acceleration Bodyroll
-          "axis": [0.0,-4.0,0]
+          "variable": "!ground_onground_2",
+          "axis": [0.0,1.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "acceleration",
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     },
-    {//How much the front right wheel will roll
-      "variable": "frBodyroll",
-      "minValue": -1.0,
-      "maxValue": 1.0,
+    {
+      "variable": "flBodyroll",//How much the front left wheel will roll
+      "minValue": -1.0,//Not inverted
+      "maxValue": 0.5,//Half value to prevent wheel from clipping into the wheel well
       "animations": [
         {
           "animationType": "translation",
-          "variable": "turn_indicator",//Steering Bodyroll
-          "axis": [0.0,0.0,-0.002]//Divide 1 by a large hundredths number for best results (1÷400 to 1÷1000, higher dividing numbers make a more stiff/less responsive suspension.)
+          "variable": "turn_indicator",
+          "axis": [0.0,-0.001,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "!ground_onground_4",//Drops suspension when this wheel is in the air
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
-        },
-        {
-          "animationType": "inhibitor",
-          "variable": "speed",//Inhibitor to keep vehicle from being very bouncy at a standstill
-          "clampMax": 0.125
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
-          "variable": "acceleration",//Acceleration Bodyroll
-          "axis": [0.0,4.0,0]
+          "variable": "!ground_onground_3",
+          "axis": [0.0,1.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "acceleration",
+          "axis": [0.0,-4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.375,0.0]
+        }
+      ]
+    },
+    {
+      "variable": "frBodyroll",//How much the front right wheel will roll
+      "minValue": -0.5,//Half value to prevent wheel from clipping into the wheel well
+      "maxValue": 1.0,//Inverted for mirroring
+      "animations": [
+        {
+          "animationType": "translation",
+          "variable": "turn_indicator",
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "!ground_onground_4",
+          "axis": [0.0,-1.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "acceleration",
+          "axis": [0.0,4.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.375,0.0]
         }
       ]
     }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/z - other/trin_pilocrap_wagon.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/z - other/trin_pilocrap_wagon.json
@@ -12,8 +12,9 @@
     "overSteerDecel": -4.0,
     "axleRatio": 3.55,
     "brakingFactor": 0.7,
-    "maxTiltAngle": -4.2,
-    "dragCoefficient": 0.4
+    "dragCoefficient": 0.4,
+    "litVariable": "running_light",
+    "panel": "mts:default_car"
   },
   "parts": [
     {
@@ -21,28 +22,33 @@
       "rot": [0.0,0.0,0.0],
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rlBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,6.0]
+          "axis": [0.0,0.0,9.0]
         }
       ]
     },
     {
       "pos": [-1.25,0.0,0.0],
       "rot": [0.0,180.0,0.0],
+      "isMirrored": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "rrBodyroll",
           "centerPoint": [-1.0E-8,0.0,0.0],
-          "axis": [0.0,0.0,6.0]
+          "axis": [0.0,0.0,9.0]
         }
       ]
     },
@@ -52,13 +58,15 @@
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "flBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -71,16 +79,19 @@
     {
       "pos": [-1.25,0.125,4.125],
       "rot": [0.0,180.0,0.0],
+      "isMirrored": true,
       "turnsWithSteer": true,
       "minValue": 0.7,
       "maxValue": 0.875,
-      "types": ["ground_wheel"],
+      "types": [
+        "ground_wheel"
+      ],
       "animations": [
         {
           "animationType": "rotation",
           "variable": "frBodyroll",
           "centerPoint": [-1.0E-8,0.0,4.125],
-          "axis": [0.0,0.0,4.0]
+          "axis": [0.0,0.0,6.0]
         },
         {
           "animationType": "rotation",
@@ -95,56 +106,74 @@
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.5,2.5625],
       "isController": true,
-      "types": ["seat"]
+      "types": [
+        "seat"
+      ]
     },
     {
       "pos": [-0.5625,0.5,2.5625],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.5,2.5625],
-      "types": ["seat"]
+      "types": [
+        "seat"
+      ]
     },
     {
       "pos": [0.5625,0.5,1.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [1.5625,0.5,1.125],
-      "types": ["seat"]
+      "types": [
+        "seat"
+      ]
     },
     {
       "pos": [-0.5625,0.5,1.125],
       "rot": [0.0,0.0,0.0],
       "dismountPos": [-1.5625,0.5,1.125],
-      "types": ["seat"]
+      "types": [
+        "seat"
+      ]
     },
     {
       "pos": [0.0,0.25,3.875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 0.25,
-      "types": ["engine_car"],
+      "types": [
+        "engine_car"
+      ],
       "linkedParts": [1,2,20,21,22]
     },
     {
       "pos": [0.0,1.9375,2.4375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_roofdevice"]
+      "types": [
+        "generic_roofdevice"
+      ]
     },
     {
       "pos": [0.0,1.9375,0.75],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["interactable_crate_roof"]
+      "types": [
+        "interactable_crate_roof"
+      ]
     },
     {
       "pos": [0.0,0.6875,5.15625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_bumper_f"]
+      "types": [
+        "generic_bodypanel_bumper_f"
+      ]
     },
     {
       "pos": [0.0,1.0625,4.65625],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_hood"],
+      "types": [
+        "generic_bodypanel_hood"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -161,20 +190,26 @@
       "pos": [1.3125,0.6875,4.21875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_fender_f"]
+      "types": [
+        "generic_bodypanel_fender_f"
+      ]
     },
     {
       "pos": [-1.3125,0.6875,4.21875],
       "rot": [0.0,0.0,0.0],
       "isMirrored": true,
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_fender_f"]
+      "types": [
+        "generic_bodypanel_fender_f"
+      ]
     },
     {
       "pos": [1.1875,1.09375,2.6875],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_door_f"],
+      "types": [
+        "generic_bodypanel_door_f"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -192,7 +227,9 @@
       "rot": [0.0,0.0,0.0],
       "isMirrored": true,
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_door_f"],
+      "types": [
+        "generic_bodypanel_door_f"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -209,7 +246,9 @@
       "pos": [1.1875,1.09375,1.4375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_door_r"],
+      "types": [
+        "generic_bodypanel_door_r"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -227,7 +266,9 @@
       "rot": [0.0,0.0,0.0],
       "isMirrored": true,
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_door_r"],
+      "types": [
+        "generic_bodypanel_door_r"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -244,20 +285,26 @@
       "pos": [1.1875,1.09375,-0.375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_fender_r"]
+      "types": [
+        "generic_bodypanel_fender_r"
+      ]
     },
     {
       "pos": [-1.1875,1.09375,-0.375],
       "rot": [0.0,0.0,0.0],
       "isMirrored": true,
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_fender_r"]
+      "types": [
+        "generic_bodypanel_fender_r"
+      ]
     },
     {
       "pos": [0.0,1.21875,-1.34375],
       "rot": [0.0,0.0,0.0],
       "maxValue": 3.0,
-      "types": ["generic_bodypanel_boot"],
+      "types": [
+        "generic_bodypanel_boot"
+      ],
       "animations": [
         {
           "animationType": "rotation",
@@ -483,9 +530,19 @@
       "subName": "_g",
       "name": "Demolition Derby Trin Pilocrap chassis and skeleton.",
       "extraMaterialLists": [
-        ["minecraft:wool:7:2","minecraft:wool:8:3"]
+        [
+          "minecraft:wool:7:2",
+          "minecraft:wool:8:3"
+        ]
       ]
     }
+  ],
+  "initialVariables": [
+    "door_fl",
+    "door_fr",
+    "door_rl",
+    "door_rr",
+    "door_hood"
   ],
   "variableModifiers": [
     {
@@ -496,9 +553,25 @@
           "variable": "engine_isautomatic_1"
         },
         {
+          "animationType": "visibility",
+          "variable": "engine_isdualclutch_1"
+        },
+        {
+          "animationType": "visibility",
+          "variable": "!engine_gear_1",
+          "reverseDelay": 6
+        },
+        {
           "animationType": "translation",
-          "variable": "!engine_clutching_1",
-          "axis": [1,0,0],
+          "variable": "!engine_clutch_downshift_1",
+          "axis": [0.5,0.0,0.0],
+          "offset": 0.5,
+          "duration": 3
+        },
+        {
+          "animationType": "translation",
+          "variable": "!engine_clutch_upshift_1",
+          "axis": [1.0,0.0,0.0],
           "duration": 3
         }
       ]
@@ -507,10 +580,8 @@
       "variable": "brakingFactor",
       "animations": [
         {
-          "animationType": "inhibitor",
-          "variable": "p_brake",
-          "clampMin": 1.0,
-          "clampMax": 1.0
+          "animationType": "visibility",
+          "variable": "p_brake"
         },
         {
           "animationType": "translation",
@@ -520,114 +591,186 @@
       ]
     },
     {
+      "variable": "axleRatio",
+      "animations": [
+        {
+          "animationType": "visibility",
+          "variable": "slip",
+          "clampMin": 8.0,
+          "clampMax": 32767.0,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.0625,0.0],
+          "offset": -0.5,
+          "clampMin": 0.001,
+          "absolute": true
+        },
+        {
+          "animationType": "translation",
+          "variable": "throttle",
+          "axis": [1.5,0.0,0.0],
+          "offset": -0.5,
+          "clampMin": 0.0125,
+          "clampMax": 1.0
+        },
+        {
+          "animationType": "translation",
+          "variable": "engine_rpm_percent_revlimit_1",
+          "axis": [-8.0,0.0,0.0],
+          "offset": 8.5,
+          "clampMin": 0.125,
+          "clampMax": 1.0
+        }
+      ]
+    },
+    {
       "variable": "rlBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_1",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rlBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "rrBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_2",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "rrBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "flBodyroll",
       "minValue": -1.0,
-      "maxValue": 1.0,
+      "maxValue": 0.5,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_3",
-          "axis": [0.0,-1.0,0.0],
-          "duration": 4
+          "axis": [0.0,-1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,-3.0,0.0]
+          "axis": [0.0,-2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "flBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     },
     {
       "variable": "frBodyroll",
-      "minValue": -1.0,
+      "minValue": -0.5,
       "maxValue": 1.0,
       "animations": [
         {
           "animationType": "translation",
           "variable": "turn_indicator",
-          "axis": [0.0,0.0,-0.00125]
+          "axis": [0.0,-0.001,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "slip",
+          "axis": [0.0,0.005,0.0]
         },
         {
           "animationType": "translation",
           "variable": "!ground_onground_4",
-          "axis": [0.0,1.0,0.0],
-          "duration": 4
+          "axis": [0.0,1.0,0.0]
         },
         {
-          "animationType": "inhibitor",
-          "variable": "speed",
-          "clampMax": 0.125
+          "animationType": "translation",
+          "variable": "damage_totaled",
+          "axis": [0.0,-1.0,0.0]
         },
         {
           "animationType": "translation",
           "variable": "acceleration",
-          "axis": [0.0,3.0,0.0]
+          "axis": [0.0,2.0,0.0]
+        },
+        {
+          "animationType": "translation",
+          "variable": "frBodyroll",
+          "axis": [0.0,-0.25,0.0]
         }
       ]
     }
@@ -829,8 +972,9 @@
         ]
       }
     ],
-    "customVariables": ["EMERLTS"],
-    "initialVariables": ["door_fl","door_fr","door_rl","door_rr","door_hood"],
+    "customVariables": [
+      "EMERLTS"
+    ],
     "sounds": [
       {
         "name": "iv_tcp_v3:horn_2",
@@ -842,16 +986,25 @@
             "clampMax": 1.0
           }
         ],
-        "looping": true
+        "looping": true,
+        "minDistance": 0.0,
+        "minDistanceVolume": 0.0,
+        "middleDistance": 0.0,
+        "middleDistanceVolume": 0.0,
+        "maxDistance": 0.0,
+        "maxDistanceVolume": 0.0
       }
     ],
     "particles": [
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [1.3125,0.15625,0.84375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -866,8 +1019,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [1.3125,0.15625,0.84375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -882,10 +1038,13 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 1,
         "transparency": 0.25,
         "toTransparency": 0.25,
-        "scale": 1.0,
+        "scale": 0.2,
+        "hitboxSize": 0.2,
         "color": "D9D9D9",
         "pos": [-1.3125,0.15625,0.84375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -900,8 +1059,11 @@
       },
       {
         "type": "smoke",
+        "spawningOrientation": "entity",
+        "renderingOrientation": "player",
         "quantity": 5,
-        "scale": 2.5,
+        "scale": 0.5,
+        "hitboxSize": 0.2,
         "color": "000000",
         "pos": [-1.3125,0.15625,0.84375],
         "initialVelocity": [0.0,0.0,-1.0],
@@ -921,10 +1083,23 @@
     "description": "Body panels come in the trin Part Pack\n\nRecommended parts:\nAverage Wheels\ni3 engine\nModel 3 Seats",
     "health": 2000,
     "materialLists": [
-      ["mts:iv_tpp.chassis_nce_ladder_t6m:0:1","minecraft:iron_ingot:0:30","minecraft:iron_block:0:7","minecraft:glowstone_dust:0:1","mts:iv_tpp.metal_pile_3:0:1"]
+      [
+        "mts:iv_tpp.chassis_nce_ladder_t6m:0:1",
+        "minecraft:iron_ingot:0:30",
+        "minecraft:iron_block:0:7",
+        "minecraft:glowstone_dust:0:1",
+        "mts:iv_tpp.metal_pile_3:0:1"
+      ]
     ],
     "repairMaterialLists": [
-      ["minecraft:iron_ingot:0:15","minecraft:iron_block:0:3","minecraft:glowstone_dust:0:1","mts:iv_tpp.metal_pile_3:0:1"]
-    ]
+      [
+        "minecraft:iron_ingot:0:15",
+        "minecraft:iron_block:0:3",
+        "minecraft:glowstone_dust:0:1",
+        "mts:iv_tpp.metal_pile_3:0:1"
+      ]
+    ],
+    "radarWidth": 0.0,
+    "radarRange": 0.0
   }
 }


### PR DESCRIPTION
Any alteration which you do not want made can be reversed or tweaked if needed

Changes are as follows (to my best memory):
All modified vehicles have a new bodyroll system, it acts smoother in comparison to the previous one
All modified vehicles now have a slip-based axleRatio increasing VM, which allows the engine to rev up when drifting. (Difficult for me to explain, better seen ingame)
All modified vehicles have their manual throttle VM modified, makes engine revmatch when downshifting and will allow engine to free-rev when in neutral regardless of current clutch state
Pilocrap right-hand side wheels are now mirrored
Transortus front doors now rotate open and independently, and TQ2/TQ3 will automatically kneel when parked+running+side doors are open

There may be other minor changes I may have forgotten to list, if you notice and find one make sure to point it out and I'll probably remember what it is!