### PR TITLE
Fixed Trin Rodeo having its right wheels facing the wrong way

### DIFF
--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_comfort.json
@@ -23,8 +23,8 @@
                 0.0,
                 0.0
             ],
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -58,8 +58,8 @@
                 0.0
             ],
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -88,8 +88,8 @@
                 3.125
             ],
             "turnsWithSteer": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -138,8 +138,8 @@
             ],
             "turnsWithSteer": true,
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_root.json
@@ -23,8 +23,8 @@
                 0.0,
                 0.0
             ],
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -58,8 +58,8 @@
                 0.0
             ],
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -88,8 +88,8 @@
                 3.125
             ],
             "turnsWithSteer": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -138,8 +138,8 @@
             ],
             "turnsWithSteer": true,
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_comfort.json
@@ -22,8 +22,8 @@
                 0.0,
                 0.0
             ],
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -57,8 +57,8 @@
                 0.0
             ],
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -87,8 +87,8 @@
                 3.125
             ],
             "turnsWithSteer": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -137,8 +137,8 @@
             ],
             "turnsWithSteer": true,
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_root.json
@@ -22,8 +22,8 @@
                 0.0,
                 0.0
             ],
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -57,8 +57,8 @@
                 0.0
             ],
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -87,8 +87,8 @@
                 3.125
             ],
             "turnsWithSteer": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -137,8 +137,8 @@
             ],
             "turnsWithSteer": true,
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_comfort.json
@@ -22,8 +22,8 @@
                 0.0,
                 0.0
             ],
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -57,8 +57,8 @@
                 0.0
             ],
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -87,8 +87,8 @@
                 3.125
             ],
             "turnsWithSteer": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -137,8 +137,8 @@
             ],
             "turnsWithSteer": true,
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_root.json
@@ -22,8 +22,8 @@
                 0.0,
                 0.0
             ],
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -57,8 +57,8 @@
                 0.0
             ],
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -87,8 +87,8 @@
                 3.125
             ],
             "turnsWithSteer": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -137,8 +137,8 @@
             ],
             "turnsWithSteer": true,
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_comfort.json
@@ -22,8 +22,8 @@
                 0.0,
                 0.0
             ],
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -57,8 +57,8 @@
                 0.0
             ],
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -87,8 +87,8 @@
                 3.125
             ],
             "turnsWithSteer": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -137,8 +137,8 @@
             ],
             "turnsWithSteer": true,
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_root.json
@@ -22,8 +22,8 @@
                 0.0,
                 0.0
             ],
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -57,8 +57,8 @@
                 0.0
             ],
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -87,8 +87,8 @@
                 3.125
             ],
             "turnsWithSteer": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],
@@ -137,8 +137,8 @@
             ],
             "turnsWithSteer": true,
             "isMirrored": true,
-            "minValue": 1.05,
-            "maxValue": 1.13,
+            "minValue": 0.75,
+            "maxValue": 1.20,
             "types": [
                 "ground_wheel"
             ],


### PR DESCRIPTION
The Trin Rodeos (all 4 types in 2 trims) had an issue where the right wheels were facing the wrong way.
While at it, the Rodeos can now take smaller wheels if desired.
This PR fixes #24 