### PR TITLE
Fixed Jumpy Suspentions / Bodyroll

### DIFF
--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_cabrio_c_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_cabrio_c_comfort.json
@@ -1141,6 +1141,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1202,6 +1208,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1263,6 +1275,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1324,6 +1342,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_cabrio_c_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_cabrio_c_root.json
@@ -1140,6 +1140,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1201,6 +1207,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1262,6 +1274,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1323,6 +1341,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_hatchback_c_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_hatchback_c_comfort.json
@@ -1163,6 +1163,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1224,6 +1230,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1285,6 +1297,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1346,6 +1364,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_hatchback_c_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_hatchback_c_root.json
@@ -1162,6 +1162,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1223,6 +1229,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1284,6 +1296,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1345,6 +1363,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_sedan_c_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_sedan_c_comfort.json
@@ -1177,6 +1177,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1238,6 +1244,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1299,6 +1311,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1360,6 +1378,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_sedan_c_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_sedan_c_root.json
@@ -1162,6 +1162,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1223,6 +1229,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1284,6 +1296,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1345,6 +1363,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_paneled_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_paneled_comfort.json
@@ -1176,6 +1176,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1237,6 +1243,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1298,6 +1310,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1359,6 +1377,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_paneled_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_paneled_root.json
@@ -1175,6 +1175,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1236,6 +1242,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1297,6 +1309,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1358,6 +1376,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_windowed_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_windowed_comfort.json
@@ -1176,6 +1176,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1237,6 +1243,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1298,6 +1310,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1359,6 +1377,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_windowed_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_econobox_van_windowed_root.json
@@ -1175,6 +1175,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1236,6 +1242,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1297,6 +1309,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1358,6 +1376,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_keipan_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_keipan_comfort.json
@@ -1041,6 +1041,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1102,6 +1108,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1163,6 +1175,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1224,6 +1242,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_keipan_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_keipan_root.json
@@ -1041,6 +1041,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1102,6 +1108,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1163,6 +1175,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1224,6 +1242,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_comfort.json
@@ -974,6 +974,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1035,6 +1041,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1096,6 +1108,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1157,6 +1175,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_cabrio_root.json
@@ -959,6 +959,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1020,6 +1026,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1081,6 +1093,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1142,6 +1160,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_comfort.json
@@ -973,6 +973,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1034,6 +1040,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1095,6 +1107,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1156,6 +1174,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_pickup_root.json
@@ -967,6 +967,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1028,6 +1034,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1089,6 +1101,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1150,6 +1168,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_comfort.json
@@ -1059,6 +1059,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1120,6 +1126,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1181,6 +1193,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1242,6 +1260,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_van_root.json
@@ -1053,6 +1053,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1114,6 +1120,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1175,6 +1187,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1236,6 +1254,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_comfort.json
@@ -1018,6 +1018,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1079,6 +1085,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1140,6 +1152,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1201,6 +1219,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_rodeo_wagon_root.json
@@ -1012,6 +1012,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1073,6 +1079,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1134,6 +1146,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1195,6 +1213,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_ropy_4door_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_ropy_4door_comfort.json
@@ -1488,6 +1488,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1556,6 +1562,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1624,6 +1636,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1692,6 +1710,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_ropy_4door_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/a - low end/trin_ropy_4door_root.json
@@ -1503,6 +1503,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1571,6 +1577,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1639,6 +1651,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1707,6 +1725,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_comfort.json
@@ -1440,6 +1440,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1510,6 +1516,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1571,6 +1583,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1632,6 +1650,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_root.json
@@ -1393,6 +1393,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1463,6 +1469,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1524,6 +1536,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1585,6 +1603,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_bultizorg_substantial.json
@@ -1479,6 +1479,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1549,6 +1555,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1610,6 +1622,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1671,6 +1689,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_comfort.json
@@ -1197,6 +1197,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1258,6 +1264,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1319,6 +1331,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1380,6 +1398,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_root.json
@@ -1158,6 +1158,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1219,6 +1225,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1280,6 +1292,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1341,6 +1359,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_cabrio_substantial.json
@@ -1215,6 +1215,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1276,6 +1282,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1337,6 +1349,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1398,6 +1416,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_comfort.json
@@ -1158,6 +1158,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1219,6 +1225,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1280,6 +1292,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1341,6 +1359,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_root.json
@@ -1119,6 +1119,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1180,6 +1186,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1241,6 +1253,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1302,6 +1320,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_devom_substantial.json
@@ -1177,6 +1177,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1238,6 +1244,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1299,6 +1311,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1360,6 +1378,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_phase1.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_phase1.json
@@ -1368,6 +1368,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1429,6 +1435,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1490,6 +1502,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1551,6 +1569,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_phase2.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_phase2.json
@@ -1408,6 +1408,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1469,6 +1475,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1530,6 +1542,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1591,6 +1609,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_specialsix.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_footpather_specialsix.json
@@ -1397,6 +1397,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1458,6 +1464,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1519,6 +1531,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1580,6 +1598,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_heavorum_crewcab_dually.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_heavorum_crewcab_dually.json
@@ -1301,6 +1301,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1342,6 +1348,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1383,6 +1395,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1424,6 +1442,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_comfort.json
@@ -962,6 +962,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1023,6 +1029,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1084,6 +1096,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1145,6 +1163,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_root.json
@@ -923,6 +923,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -984,6 +990,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1045,6 +1057,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1106,6 +1124,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_springbok_substantial.json
@@ -1014,6 +1014,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1075,6 +1081,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1136,6 +1148,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1197,6 +1215,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_comfort.json
@@ -1446,6 +1446,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1507,6 +1513,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1568,6 +1580,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1629,6 +1647,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_root.json
@@ -1402,6 +1402,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1463,6 +1469,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1524,6 +1536,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1585,6 +1603,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_pickup_substantial.json
@@ -1492,6 +1492,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1553,6 +1559,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1614,6 +1626,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1675,6 +1693,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_comfort.json
@@ -1584,6 +1584,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1645,6 +1651,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1706,6 +1718,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1767,6 +1785,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_root.json
@@ -1539,6 +1539,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1600,6 +1606,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1661,6 +1673,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1722,6 +1740,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_trainingor_suv_substantial.json
@@ -1626,6 +1626,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1687,6 +1693,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1748,6 +1760,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1809,6 +1827,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_comfort.json
@@ -1329,6 +1329,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1390,6 +1396,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1451,6 +1463,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1512,6 +1530,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_root.json
@@ -1290,6 +1290,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1351,6 +1357,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1412,6 +1424,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1473,6 +1491,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_compass_substantial.json
@@ -1391,6 +1391,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1452,6 +1458,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1513,6 +1525,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1574,6 +1592,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_comfort.json
@@ -1329,6 +1329,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1390,6 +1396,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1451,6 +1463,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1512,6 +1530,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_root.json
@@ -1290,6 +1290,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1351,6 +1357,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1412,6 +1424,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1473,6 +1491,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_n_substantial.json
@@ -1390,6 +1390,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1451,6 +1457,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1512,6 +1524,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1573,6 +1591,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_v4.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_sedan_v4.json
@@ -1441,6 +1441,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1502,6 +1508,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1563,6 +1575,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1624,6 +1642,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_comfort.json
@@ -1368,6 +1368,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1429,6 +1435,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1490,6 +1502,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1551,6 +1569,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_root.json
@@ -1329,6 +1329,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1390,6 +1396,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1451,6 +1463,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1512,6 +1530,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/b - mid end/trin_urlon_wagon_substantial.json
@@ -1429,6 +1429,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1490,6 +1496,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1551,6 +1563,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1612,6 +1630,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_comfort.json
@@ -1159,6 +1159,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1220,6 +1226,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1281,6 +1293,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1342,6 +1360,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_root.json
@@ -1120,6 +1120,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1181,6 +1187,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1242,6 +1254,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1303,6 +1321,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_flugoral_substantial.json
@@ -1198,6 +1198,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1259,6 +1265,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1320,6 +1332,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1381,6 +1399,12 @@
                         -0.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_pickup_2door.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_pickup_2door.json
@@ -1394,6 +1394,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1455,6 +1461,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1516,6 +1528,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1577,6 +1595,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_2door.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_2door.json
@@ -1426,6 +1426,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1487,6 +1493,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1548,6 +1560,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1609,6 +1627,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_4door.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_4door.json
@@ -1764,6 +1764,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1825,6 +1831,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1886,6 +1898,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1947,6 +1965,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_cabrio_2door.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_gobig_suv_cabrio_2door.json
@@ -1399,6 +1399,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1460,6 +1466,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1521,6 +1533,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1582,6 +1600,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_comfort.json
@@ -1333,6 +1333,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1394,6 +1400,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1455,6 +1467,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1516,6 +1534,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_root.json
@@ -1294,6 +1294,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1355,6 +1361,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1416,6 +1428,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1477,6 +1495,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_large_substantial.json
@@ -1361,6 +1361,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1422,6 +1428,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1483,6 +1495,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1544,6 +1562,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_comfort.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_comfort.json
@@ -1197,6 +1197,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1258,6 +1264,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1319,6 +1331,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1380,6 +1398,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_root.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_root.json
@@ -1169,6 +1169,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1230,6 +1236,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1291,6 +1303,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1352,6 +1370,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_substantial.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/c - high end/trin_sportail_small_substantial.json
@@ -1236,6 +1236,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1297,6 +1303,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1358,6 +1370,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1419,6 +1437,12 @@
                         -0.375,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/z - other/trin_pilocrap_wagon.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_civil/jsondefs/vehicles/z - other/trin_pilocrap_wagon.json
@@ -1128,6 +1128,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1189,6 +1195,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1250,6 +1262,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1311,6 +1329,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_service/jsondefs/vehicles/trin_footpather_service.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_service/jsondefs/vehicles/trin_footpather_service.json
@@ -1720,6 +1720,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1781,6 +1787,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1842,6 +1854,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1903,6 +1921,12 @@
                         -0.25,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_service/jsondefs/vehicles/trin_ropy_4door_police.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_service/jsondefs/vehicles/trin_ropy_4door_police.json
@@ -1540,6 +1540,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1581,6 +1587,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1622,6 +1634,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1663,6 +1681,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_txs/jsondefs/vehicles/trin_formula.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_txs/jsondefs/vehicles/trin_formula.json
@@ -645,6 +645,12 @@
                         1.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -685,6 +691,12 @@
                         -1.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -725,6 +737,12 @@
                         -1.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -765,6 +783,12 @@
                         1.5,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_txs/jsondefs/vehicles/trin_gobig_txs_pickup_6x6.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_txs/jsondefs/vehicles/trin_gobig_txs_pickup_6x6.json
@@ -2109,6 +2109,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -2149,6 +2155,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -2189,6 +2201,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -2229,6 +2247,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_txs/jsondefs/vehicles/trin_gobig_txs_suv_4x4.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_txs/jsondefs/vehicles/trin_gobig_txs_suv_4x4.json
@@ -1865,6 +1865,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1905,6 +1911,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1945,6 +1957,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1985,6 +2003,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_txs/jsondefs/vehicles/trin_sportail_small_txs.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_txs/jsondefs/vehicles/trin_sportail_small_txs.json
@@ -871,6 +871,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -911,6 +917,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -951,6 +963,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -991,6 +1009,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_bolter_tq1.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_bolter_tq1.json
@@ -1003,6 +1003,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1053,6 +1059,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1093,6 +1105,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1133,6 +1151,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_bolter_tq2.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_bolter_tq2.json
@@ -1029,6 +1029,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1079,6 +1085,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1119,6 +1131,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1159,6 +1177,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_bolter_tq3.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_bolter_tq3.json
@@ -1014,6 +1014,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1064,6 +1070,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1104,6 +1116,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1144,6 +1162,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_capro3axle_tq1.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_capro3axle_tq1.json
@@ -1391,6 +1391,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1431,6 +1437,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_capro3axle_tq2.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_capro3axle_tq2.json
@@ -1391,6 +1391,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1431,6 +1437,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_capro3axle_tq3.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_capro3axle_tq3.json
@@ -1406,6 +1406,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1446,6 +1452,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_halfwindow_tq1.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_halfwindow_tq1.json
@@ -1521,6 +1521,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1561,6 +1567,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1601,6 +1613,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1641,6 +1659,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_halfwindow_tq2.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_halfwindow_tq2.json
@@ -1521,6 +1521,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1561,6 +1567,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1601,6 +1613,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1641,6 +1659,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_halfwindow_tq3.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_halfwindow_tq3.json
@@ -1522,6 +1522,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1562,6 +1568,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1602,6 +1614,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1642,6 +1660,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_minibus_tq1.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_minibus_tq1.json
@@ -1413,6 +1413,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1453,6 +1459,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1493,6 +1505,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1533,6 +1551,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_minibus_tq2.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_minibus_tq2.json
@@ -1413,6 +1413,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1453,6 +1459,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1493,6 +1505,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1533,6 +1551,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_minibus_tq3.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_minibus_tq3.json
@@ -1414,6 +1414,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1454,6 +1460,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1494,6 +1506,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1534,6 +1552,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_panel_tq1.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_panel_tq1.json
@@ -1537,6 +1537,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1577,6 +1583,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1617,6 +1629,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1657,6 +1675,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_panel_tq2.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_panel_tq2.json
@@ -1521,6 +1521,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1561,6 +1567,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1601,6 +1613,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1641,6 +1659,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_panel_tq3.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_panel_tq3.json
@@ -1522,6 +1522,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1562,6 +1568,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1602,6 +1614,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1642,6 +1660,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_pickup_tq1.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_pickup_tq1.json
@@ -1306,6 +1306,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1346,6 +1352,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1386,6 +1398,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1426,6 +1444,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_pickup_tq2.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_pickup_tq2.json
@@ -1306,6 +1306,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1346,6 +1352,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1386,6 +1398,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1426,6 +1444,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_pickup_tq3.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_foragon_nrml_pickup_tq3.json
@@ -1307,6 +1307,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1347,6 +1353,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1387,6 +1399,12 @@
                         -4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1427,6 +1445,12 @@
                         4.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_mod_truck_tq1.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_mod_truck_tq1.json
@@ -1496,6 +1496,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1536,6 +1542,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_mod_truck_tq2.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_mod_truck_tq2.json
@@ -1496,6 +1496,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1536,6 +1542,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_mod_truck_tq3.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_mod_truck_tq3.json
@@ -1496,6 +1496,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1536,6 +1542,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_semi_truck_s_tq1.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_semi_truck_s_tq1.json
@@ -1465,6 +1465,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1505,6 +1511,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_semi_truck_s_tq2.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_semi_truck_s_tq2.json
@@ -1465,6 +1465,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1505,6 +1511,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_semi_truck_s_tq3.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_juggernaut_semi_truck_s_tq3.json
@@ -1465,6 +1465,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1505,6 +1511,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_tormador_tq1.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_tormador_tq1.json
@@ -1621,6 +1621,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1661,6 +1667,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_tormador_tq2.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_tormador_tq2.json
@@ -1702,6 +1702,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1742,6 +1748,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_tormador_tq3.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_tormador_tq3.json
@@ -1768,6 +1768,12 @@
                         -3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1808,6 +1814,12 @@
                         3.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_transortus.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_transortus.json
@@ -1454,6 +1454,12 @@
                         5.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1494,6 +1500,12 @@
                         -5.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1534,6 +1546,12 @@
                         -5.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1574,6 +1592,12 @@
                         5.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         }

--- a/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_transortus_crystal.json
+++ b/mccore/src/main/resources/assets/iv_tcp_v3_utility/jsondefs/vehicles/trin_transortus_crystal.json
@@ -1497,6 +1497,12 @@
                         5.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1547,6 +1553,12 @@
                         -5.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1587,6 +1599,12 @@
                         -5.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },
@@ -1627,6 +1645,12 @@
                         5.0,
                         0.0
                     ]
+                },
+                {
+                    "animationType": "visibility",
+                    "variable": "engine_running_1",
+                    "clampMin": 1.0,
+                    "clampMax": 1.0
                 }
             ]
         },


### PR DESCRIPTION
This was mostly done by a script I added to **[Trin-Pack-Creator](https://github.com/TheOddlySeagull/Trin-Pack-Creator)**.

All models that had **body roll** implemented were affected by recent MTS updates: they became jumpy, causing vehicles to slowly drift away from their position and look bad.
This has now been resolved by **disabling suspension and body roll whenever the engine is turned off**.

This PR resolves #29
